### PR TITLE
JXPATH-180 Use existing reference to BeanInfo

### DIFF
--- a/src/main/java/org/apache/commons/jxpath/ri/model/beans/BeanPointer.java
+++ b/src/main/java/org/apache/commons/jxpath/ri/model/beans/BeanPointer.java
@@ -100,7 +100,7 @@ public class BeanPointer extends PropertyOwnerPointer {
     public boolean isLeaf() {
         Object value = getNode();
         return value == null
-            || JXPathIntrospector.getBeanInfo(value.getClass()).isAtomic();
+            || this.beanInfo.isAtomic();
     }
 
     public int hashCode() {


### PR DESCRIPTION
Use existing reference to BeanInfo instead than retrieving it, as per https://issues.apache.org/jira/browse/JXPATH-180
