### PR TITLE
Fix Flaky Tests

### DIFF
--- a/src/test/java/org/apache/commons/jxpath/TestBean.java
+++ b/src/test/java/org/apache/commons/jxpath/TestBean.java
@@ -18,7 +18,7 @@ package org.apache.commons.jxpath;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -155,10 +155,10 @@ public class TestBean {
     /**
      * A heterogeneous set: String, Integer, NestedTestBean
      */
-    private HashSet set;
+    private LinkedHashSet set;
     public Set getSet() {
         if (set == null) {
-            set = new HashSet();
+            set = new LinkedHashSet();
             set.add("String 4");
             set.add(Integer.valueOf(4));
             set.add(new NestedTestBean("Name 4"));


### PR DESCRIPTION
### Description
Eleven tests were found to be flaky using [nondex](https://github.com/TestingResearchIllinois/NonDex):
```
org.apache.commons.jxpath.ri.compiler.ExtensionFunctionTest#testExpressionContext
org.apache.commons.jxpath.ri.model.beans.BeanModelTest#testAxisDescendantOrSelf
org.apache.commons.jxpath.ri.model.beans.BeanModelTest#testAxisParent
org.apache.commons.jxpath.ri.model.beans.BeanModelTest#testAxisFollowing
org.apache.commons.jxpath.ri.model.beans.BeanModelTest#testBooleanPredicate
org.apache.commons.jxpath.ri.model.beans.BeanModelTest#testAxisDescendant
org.apache.commons.jxpath.ri.model.beans.BeanModelTest#testAxisFollowingSibling
org.apache.commons.jxpath.ri.model.dynabeans.DynaBeanModelTest#testAxisDescendantOrSelf
org.apache.commons.jxpath.ri.model.dynabeans.DynaBeanModelTest#testAxisParent
org.apache.commons.jxpath.ri.model.dynabeans.DynaBeanModelTest#testAxisFollowing
org.apache.commons.jxpath.ri.model.dynabeans.DynaBeanModelTest#testAxisDescendant
```
The flakiness can be reproduced by running:
```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex \
-Dtest=[test_path] \
-Drat.skip=true
```

flaky tests failures:
```[ERROR] Failures: 
[ERROR]   ExtensionFunctionTest.testExpressionContext:277->JXPathTestCase.assertXPathValue:49 Evaluating <test:count(//strings)> expected:<21> but was:<24>
[ERROR]   BeanModelTest>BeanModelTestCase.testAxisDescendant:388->JXPathTestCase.assertXPathValue:49 Evaluating <count(descendant::node())> expected:<65.0> but was:<59.0>
[ERROR]   BeanModelTest>BeanModelTestCase.testAxisDescendantOrSelf:411->JXPathTestCase.assertXPathValueIterator:152 Evaluating value iterator <//name> expected:<[Name 2, Name 0, Name 5, Name 6, Name 4, Name 3, Name 1]> but was:<[Name 1, Name 2, Name 3, Name 0, Name 5, Name 6]>
[ERROR]   BeanModelTest>BeanModelTestCase.testAxisFollowing:445->JXPathTestCase.assertXPathValue:49 Evaluating <count(nestedBean/strings[2]/following::node())> expected:<21.0> but was:<15.0>
[ERROR]   BeanModelTest>BeanModelTestCase.testAxisFollowingSibling:480->JXPathTestCase.assertXPathValue:49 Evaluating <count(/descendant::boolean/following-sibling::node())> expected:<53.0> but was:<63.0>
[ERROR]   BeanModelTest>BeanModelTestCase.testAxisParent:495->JXPathTestCase.assertXPathValue:49 Evaluating <count(//..)> expected:<9.0> but was:<11.0>
[ERROR]   BeanModelTest>BeanModelTestCase.testBooleanPredicate:681->JXPathTestCase.assertXPathValueIterator:152 Evaluating value iterator <//self::node()[name(.) = concat('n', 'a', 'm', 'e')]> expected:<[Name 1, Name 2, Name 3, Name 6, Name 0, Name 5, Name 4]> but was:<[Name 1, Name 2, Name 3, Name 6, Name 0, Name 5]>
[ERROR]   DynaBeanModelTest>BeanModelTestCase.testAxisDescendant:388->JXPathTestCase.assertXPathValue:49 Evaluating <count(descendant::node())> expected:<65.0> but was:<71.0>
[ERROR]   DynaBeanModelTest>BeanModelTestCase.testAxisDescendantOrSelf:436->JXPathTestCase.assertXPathValue:49 Evaluating <count(descendant-or-self::node())> expected:<66.0> but was:<60.0>
[ERROR]   DynaBeanModelTest>BeanModelTestCase.testAxisFollowing:450->JXPathTestCase.assertXPathValue:49 Evaluating <count(nestedBean/strings[2]/following::strings)> expected:<7.0> but was:<10.0>
[ERROR]   DynaBeanModelTest>BeanModelTestCase.testAxisParent:495->JXPathTestCase.assertXPathValue:49 Evaluating <count(//..)> expected:<9.0> but was:<10.0>
```
These eleven tests have the same root cause for flakiness: their passing depends on the order of elements stored in the set returned by ```getSet()``` in ```TestBean``` class, which is not deterministic with HashSet implementation.

### Proposed Fix
This pr proposes a simple fix by replacing HashSet with LinkedHashSet in ```TestBean```. After this fix, all eleven tests now pass consistently.







