### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <email>ggregory at apache.org</email>
       <url>https://www.garygregory.com</url>
       <organization>The Apache Software Foundation</organization>
-      <organizationUrl>https://www.apache.org/</organizationUrl>      
+      <organizationUrl>https://www.apache.org/</organizationUrl>
       <roles>
         <role>PMC Member</role>
       </roles>
@@ -105,7 +105,7 @@
     <commons.jacoco.branchRatio>0.68</commons.jacoco.branchRatio>
     <commons.jacoco.lineRatio>0.77</commons.jacoco.lineRatio>
     <commons.jacoco.complexityRatio>0.64</commons.jacoco.complexityRatio>
-  </properties> 
+  </properties>
   <build>
     <defaultGoal>clean apache-rat:check verify japicmp:cmp checkstyle:check pmd:check javadoc:javadoc</defaultGoal>
     <plugins>
@@ -157,7 +157,7 @@
             <link>https://commons.apache.org/proper/commons-beanutils/apidocs</link>
             <link>https://commons.apache.org/proper/commons-lang/apidocs</link>
             <!-- http://www.jdom.org/docs/apidocs/ is not a secure link -->
-            <link>https://javadoc.io/doc/org.jdom/jdom/1.1</link> 
+            <link>https://javadoc.io/doc/org.jdom/jdom/1.1</link>
           </links>
         </configuration>
       </plugin>
@@ -215,9 +215,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.11.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -310,7 +310,7 @@
             <link>http://java.sun.com/j2se/1.3/docs/api/</link>
             <link>http://java.sun.com/javaee/5/docs/api/</link>
             <link>http://commons.apache.org/beanutils/apidocs/</link>
-            <link>http://www.jdom.org/docs/apidocs/</link> 
+            <link>http://www.jdom.org/docs/apidocs/</link>
           </links>
         </configuration>
       </plugin>

--- a/src/test/java/org/apache/commons/jxpath/AbstractJXPathTest.java
+++ b/src/test/java/org/apache/commons/jxpath/AbstractJXPathTest.java
@@ -26,18 +26,24 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.jxpath.ri.model.NodePointer;
+import org.junit.jupiter.api.BeforeEach;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract superclass for various JXPath tests.
  */
-public abstract class AbstractJXPathTest extends TestCase {
+public abstract class AbstractJXPathTest {
 
     /**
      * Constructs a new instance of this test case.
+     *
+     * @throws Exception In case of errors during setup
      */
-    public AbstractJXPathTest() {
+    @BeforeEach
+    protected void setUp() throws Exception
+    {
         Locale.setDefault(Locale.US);
     }
 
@@ -46,7 +52,7 @@ public abstract class AbstractJXPathTest extends TestCase {
     {
         ctx.setLenient(false);
         final Object actual = ctx.getValue(xpath);
-        assertEquals("Evaluating <" + xpath + ">", expected, actual);
+        assertEquals(expected, actual, "Evaluating <" + xpath + ">");
     }
 
     protected void assertXPathValue(final JXPathContext ctx,
@@ -54,7 +60,7 @@ public abstract class AbstractJXPathTest extends TestCase {
     {
         ctx.setLenient(false);
         final Object actual = ctx.getValue(xpath, resultType);
-        assertEquals("Evaluating <" + xpath + ">", expected, actual);
+        assertEquals(expected, actual, "Evaluating <" + xpath + ">");
     }
 
     protected void assertXPathValueLenient(final JXPathContext ctx,
@@ -63,7 +69,7 @@ public abstract class AbstractJXPathTest extends TestCase {
         ctx.setLenient(true);
         final Object actual = ctx.getValue(xpath);
         ctx.setLenient(false);
-        assertEquals("Evaluating lenient <" + xpath + ">", expected, actual);
+        assertEquals(expected, actual, "Evaluating lenient <" + xpath + ">");
     }
 
     protected void assertXPathSetValue(final JXPathContext ctx,
@@ -77,7 +83,7 @@ public abstract class AbstractJXPathTest extends TestCase {
     {
         ctx.setValue(xpath, value);
         final Object actual = ctx.getValue(xpath);
-        assertEquals("Modifying <" + xpath + ">", expected, actual);
+        assertEquals(expected, actual, "Modifying <" + xpath + ">");
     }
 
     protected void assertXPathCreatePath(final JXPathContext ctx,
@@ -85,14 +91,14 @@ public abstract class AbstractJXPathTest extends TestCase {
                 final Object expectedValue, final String expectedPath)
     {
         final Pointer pointer = ctx.createPath(xpath);
-        assertEquals("Creating path <" + xpath + ">",
-                expectedPath, pointer.asPath());
+        assertEquals(expectedPath, pointer.asPath(),
+                "Creating path <" + xpath + ">");
 
-        assertEquals("Creating path (pointer value) <" + xpath + ">",
-                expectedValue, pointer.getValue());
+        assertEquals(expectedValue, pointer.getValue(),
+                "Creating path (pointer value) <" + xpath + ">");
 
-        assertEquals("Creating path (context value) <" + xpath + ">",
-                expectedValue, ctx.getValue(pointer.asPath()));
+        assertEquals(expectedValue, ctx.getValue(pointer.asPath()),
+                "Creating path (context value) <" + xpath + ">");
     }
 
     protected void assertXPathCreatePathAndSetValue(final JXPathContext ctx,
@@ -100,14 +106,14 @@ public abstract class AbstractJXPathTest extends TestCase {
                 final String expectedPath)
     {
         final Pointer pointer = ctx.createPathAndSetValue(xpath, value);
-        assertEquals("Creating path <" + xpath + ">",
-                expectedPath, pointer.asPath());
+        assertEquals(expectedPath, pointer.asPath(),
+                "Creating path <" + xpath + ">");
 
-        assertEquals("Creating path (pointer value) <" + xpath + ">",
-                value, pointer.getValue());
+        assertEquals(value, pointer.getValue(),
+                "Creating path (pointer value) <" + xpath + ">");
 
-        assertEquals("Creating path (context value) <" + xpath + ">",
-                value, ctx.getValue(pointer.asPath()));
+        assertEquals(value, ctx.getValue(pointer.asPath()),
+                "Creating path (context value) <" + xpath + ">");
     }
 
     protected void assertXPathPointer(final JXPathContext ctx,
@@ -116,7 +122,7 @@ public abstract class AbstractJXPathTest extends TestCase {
         ctx.setLenient(false);
         final Pointer pointer = ctx.getPointer(xpath);
         final String actual = pointer.toString();
-        assertEquals("Evaluating pointer <" + xpath + ">", expected, actual);
+        assertEquals(expected, actual, "Evaluating pointer <" + xpath + ">");
     }
 
     protected void assertXPathPointerLenient(final JXPathContext ctx,
@@ -125,7 +131,7 @@ public abstract class AbstractJXPathTest extends TestCase {
         ctx.setLenient(true);
         final Pointer pointer = ctx.getPointer(xpath);
         final String actual = pointer.toString();
-        assertEquals("Evaluating pointer <" + xpath + ">", expected, actual);
+        assertEquals(expected, actual, "Evaluating pointer <" + xpath + ">");
     }
 
     protected void assertXPathValueAndPointer(final JXPathContext ctx,
@@ -148,10 +154,12 @@ public abstract class AbstractJXPathTest extends TestCase {
         while (it.hasNext()) {
             actual.add(it.next());
         }
-        assertEquals(String.format("[hashCode()] Evaluating value iterator <%s>, expected.class %s(%,d): %s, actual.class %s(%,d): %s", xpath,
-                expected.getClass(), expected.size(), expected, actual.getClass(), actual.size(), actual), expected.hashCode(), actual.hashCode());
-        assertEquals(String.format("[equals()] Evaluating value iterator <%s>, expected.class %s(%,d): %s, actual.class %s(%,d): %s", xpath,
-                expected.getClass(), expected.size(), expected, actual.getClass(), actual.size(), actual), expected, actual);
+        assertEquals(expected.hashCode(), actual.hashCode(),
+                String.format("[hashCode()] Evaluating value iterator <%s>, expected.class %s(%,d): %s, actual.class %s(%,d): %s", xpath,
+                        expected.getClass(), expected.size(), expected, actual.getClass(), actual.size(), actual));
+        assertEquals(expected, actual,
+                String.format("[equals()] Evaluating value iterator <%s>, expected.class %s(%,d): %s, actual.class %s(%,d): %s", xpath,
+                        expected.getClass(), expected.size(), expected, actual.getClass(), actual.size(), actual));
     }
 
     protected void assertXPathPointerIterator(
@@ -172,9 +180,9 @@ public abstract class AbstractJXPathTest extends TestCase {
             actual.add(pointer.toString());
         }
         assertEquals(
-            "Evaluating pointer iterator <" + xpath + ">",
             expected,
-            actual);
+            actual,
+            "Evaluating pointer iterator <" + xpath + ">");
     }
 
     protected void assertDocumentOrder(
@@ -193,9 +201,9 @@ public abstract class AbstractJXPathTest extends TestCase {
             res = 1;
         }
         assertEquals(
-            "Comparing paths '" + path1 + "' and '" + path2 + "'",
             expected,
-            res);
+            res,
+            "Comparing paths '" + path1 + "' and '" + path2 + "'");
     }
 
     protected void assertXPathValueType(
@@ -205,8 +213,7 @@ public abstract class AbstractJXPathTest extends TestCase {
     {
         ctx.setLenient(false);
         final Object actual = ctx.getValue(xpath);
-        assertTrue("Evaluating <" + xpath + "> = " + actual.getClass(),
-                clazz.isAssignableFrom(actual.getClass()));
+        assertTrue(clazz.isAssignableFrom(actual.getClass()), "Evaluating <" + xpath + "> = " + actual.getClass());
     }
 
     protected void assertXPathNodeType(
@@ -216,8 +223,8 @@ public abstract class AbstractJXPathTest extends TestCase {
     {
         ctx.setLenient(false);
         final Pointer actual = ctx.getPointer(xpath);
-        assertTrue("Evaluating <" + xpath + "> = " + actual.getNode().getClass(),
-                clazz.isAssignableFrom(actual.getNode().getClass()));
+        assertTrue(clazz.isAssignableFrom(actual.getNode().getClass()),
+                "Evaluating <" + xpath + "> = " + actual.getNode().getClass());
     }
 
     protected static List list() {

--- a/src/test/java/org/apache/commons/jxpath/BasicNodeSetTest.java
+++ b/src/test/java/org/apache/commons/jxpath/BasicNodeSetTest.java
@@ -19,7 +19,11 @@ package org.apache.commons.jxpath;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test BasicNodeSet
@@ -33,6 +37,7 @@ public class BasicNodeSetTest extends AbstractJXPathTest {
     protected BasicNodeSet nodeSet;
 
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         context = JXPathContext.newContext(new TestMixedModelBean());
@@ -75,10 +80,12 @@ public class BasicNodeSetTest extends AbstractJXPathTest {
     /**
      * Test adding pointers.
      */
+    @Test
     public void testAdd() {
         addPointers("/bean/integers");
-        assertEquals(nodeSet.getPointers().toString(), list("/bean/integers[1]",
-                "/bean/integers[2]", "/bean/integers[3]", "/bean/integers[4]").toString());
+        assertEquals(list("/bean/integers[1]",
+                "/bean/integers[2]", "/bean/integers[3]", "/bean/integers[4]").toString(),
+                nodeSet.getPointers().toString());
         assertEquals(list(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3),
                 Integer.valueOf(4)), nodeSet.getValues());
         assertEquals(list(Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(3),
@@ -88,6 +95,7 @@ public class BasicNodeSetTest extends AbstractJXPathTest {
     /**
      * Test removing a pointer.
      */
+    @Test
     public void testRemove() {
         addPointers("/bean/integers");
         removePointers("/bean/integers[4]");
@@ -102,6 +110,7 @@ public class BasicNodeSetTest extends AbstractJXPathTest {
     /**
      * Demonstrate when nodes != values:  in XML models.
      */
+    @Test
     public void testNodes() {
         addPointers("/document/vendor/contact");
         assertEquals(list("/document/vendor[1]/contact[1]",

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath113Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath113Test.java
@@ -24,12 +24,14 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
 public class JXPath113Test extends AbstractJXPathTest
 {
 
+    @Test
     public void testIssue113() throws Exception
     {
         final Document doc = JAXP.getDocument("<xml/>");

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath118Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath118Test.java
@@ -21,23 +21,25 @@ import java.util.Iterator;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.Pointer;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Testcase proving JXPATH-118 issue with asPath() returning wrong names.
  */
-public class JXPath118Test extends TestCase
+public class JXPath118Test
 {
 
+    @Test
     public void testJXPATH118IssueWithAsPath() throws Exception
     {
         final Object contextBean = new SomeChildClass();
         final JXPathContext context = JXPathContext.newContext(contextBean);
         final Iterator<Pointer> iteratePointers = context.iteratePointers("//*");
-        Assert.assertEquals("/bar", iteratePointers.next().asPath());
-        Assert.assertEquals("/baz", iteratePointers.next().asPath());
-        Assert.assertEquals("/foo", iteratePointers.next().asPath());
+        assertEquals("/bar", iteratePointers.next().asPath());
+        assertEquals("/baz", iteratePointers.next().asPath());
+        assertEquals("/foo", iteratePointers.next().asPath());
     }
 
     public static class SomeChildClass

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath149Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath149Test.java
@@ -18,9 +18,11 @@ package org.apache.commons.jxpath.issues;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.Test;
 
 public class JXPath149Test extends AbstractJXPathTest {
 
+    @Test
     public void testComplexOperationWithVariables() {
         final JXPathContext context = JXPathContext.newContext(null);
         context.getVariables().declareVariable("a", Integer.valueOf(0));

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath172DynamicTest.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath172DynamicTest.java
@@ -23,25 +23,22 @@ import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.Pointer;
 import org.apache.commons.jxpath.ri.model.dynamic.DynamicPropertyPointer;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class JXPath172DynamicTest extends AbstractJXPathTest
 {
 
-    /**
-     * Return the tests included in this test suite.
-     */
-    public static TestSuite suite()
-    {
-        return new TestSuite(JXPath172DynamicTest.class);
-    }
-
+    @Test
     public void testIssue172_propertyExistAndIsNotNull()
     {
         final JXPathContext context = getContext("ciao", false);
         final Object bRet = context.selectSingleNode("value");
-        assertNotNull("null!!", bRet);
-        assertEquals("Is " + bRet.getClass(), "ciao", bRet);
+        assertNotNull(bRet, "null!!");
+        assertEquals("ciao", bRet, "Is " + bRet.getClass());
 
         final Pointer pointer = context.getPointer("value");
         assertNotNull(pointer);
@@ -49,11 +46,12 @@ public class JXPath172DynamicTest extends AbstractJXPathTest
         assertEquals("ciao", pointer.getValue());
     }
 
+    @Test
     public void testIssue172_propertyExistAndIsNull()
     {
         final JXPathContext context = getContext(null, false);
         final Object bRet = context.selectSingleNode("value");
-        assertNull("not null!!", bRet);
+        assertNull(bRet,"not null!!");
 
         final Pointer pointer = context.getPointer("value");
         assertNotNull(pointer);
@@ -61,6 +59,7 @@ public class JXPath172DynamicTest extends AbstractJXPathTest
         assertNull(pointer.getValue());
     }
 
+    @Test
     public void testIssue172_propertyDoesNotExist()
     {
         final JXPathContext context = getContext(null, false);
@@ -73,6 +72,7 @@ public class JXPath172DynamicTest extends AbstractJXPathTest
 
     }
 
+    @Test
     public void testIssue172_propertyDoesNotExist_Lenient()
     {
         final JXPathContext context = getContext(null, true);
@@ -85,6 +85,7 @@ public class JXPath172DynamicTest extends AbstractJXPathTest
 
     }
 
+    @Test
     public void testIssue172_nestedpropertyDoesNotExist_Lenient()
     {
         final JXPathContext context = getContext(null, true);
@@ -97,6 +98,7 @@ public class JXPath172DynamicTest extends AbstractJXPathTest
 
     }
 
+    @Test
     public void testIssue172_nestedpropertyDoesNotExist_NotLenient()
     {
         final JXPathContext context = getContext(null, false);

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath172Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath172Test.java
@@ -23,25 +23,23 @@ import org.apache.commons.jxpath.Pointer;
 import org.apache.commons.jxpath.ri.model.beans.BeanPropertyPointer;
 import org.apache.commons.jxpath.ri.model.beans.NullPropertyPointer;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class JXPath172Test extends AbstractJXPathTest
 {
 
-    /**
-     * Return the tests included in this test suite.
-     */
-    public static TestSuite suite()
-    {
-        return new TestSuite(JXPath172Test.class);
-    }
-
+    @Test
     public void testIssue172_propertyExistAndIsNotNull()
     {
         final JXPathContext context = getContext("ciao", false);
         final Object bRet = context.selectSingleNode("value");
-        assertNotNull("null!!", bRet);
-        assertEquals("Is " + bRet.getClass(), "ciao", bRet);
+        assertNotNull(bRet, "null!!");
+        assertEquals("ciao", bRet, "Is " + bRet.getClass());
 
         final Pointer pointer = context.getPointer("value");
         assertNotNull(pointer);
@@ -49,11 +47,12 @@ public class JXPath172Test extends AbstractJXPathTest
         assertEquals("ciao", pointer.getValue());
     }
 
+    @Test
     public void testIssue172_propertyExistAndIsNull()
     {
         final JXPathContext context = getContext(null, false);
         final Object bRet = context.selectSingleNode("value");
-        assertNull("not null!!", bRet);
+        assertNull(bRet, "not null!!");
 
         final Pointer pointer = context.getPointer("value");
         assertNotNull(pointer);
@@ -61,11 +60,12 @@ public class JXPath172Test extends AbstractJXPathTest
         assertNull(pointer.getValue());
     }
 
+    @Test
     public void testIssue172_PropertyUnexisting()
     {
         final JXPathContext context = getContext(null, true);
         final Object bRet = context.selectSingleNode("unexisting");
-        assertNull("not null!!", bRet);
+        assertNull(bRet, "not null!!");
 
         final Pointer pointer = context.getPointer("unexisting");
         assertNotNull(pointer);
@@ -73,11 +73,12 @@ public class JXPath172Test extends AbstractJXPathTest
         assertNull(pointer.getValue());
     }
 
+    @Test
     public void testIssue172_NestedPropertyUnexisting()
     {
         final JXPathContext context = getContext(null, true);
         final Object bRet = context.selectSingleNode("value.child");
-        assertNull("not null!!", bRet);
+        assertNull(bRet, "not null!!");
 
         final Pointer pointer = context.getPointer("value.child");
         assertNotNull(pointer);
@@ -85,13 +86,14 @@ public class JXPath172Test extends AbstractJXPathTest
         assertNull(pointer.getValue());
     }
 
+    @Test
     public void testIssue172_propertyDoesNotExist_NotLenient()
     {
         final JXPathContext context = getContext(null, false);
         try
         {
             final Object bRet = context.selectSingleNode("unexisting");
-            fail(" " + bRet);
+            fail("" + bRet);
         }
         catch (final JXPathNotFoundException e)
         {

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath177Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath177Test.java
@@ -23,9 +23,12 @@ import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.Pointer;
 import org.apache.commons.jxpath.Variables;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class JXPath177Test extends TestCase
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class JXPath177Test
 {
     Map model = new HashMap();
     {
@@ -36,17 +39,22 @@ public class JXPath177Test extends TestCase
         x.put("name", "X name");
     }
 
+    @Test
     public void testJx177()
     {
         doTest("name", "ROOT name");
         doTest("/x/name", "X name");
         doTest("$__root/x/name", "X name");
     }
+
+    @Test
     public void testJx177_Union1()
     {
         doTest("$__root/x/name|name", "X name");
 
     }
+
+    @Test
     public void testJx177_Union2()
     {
         doTest("$__root/x/unexisting|name", "ROOT name");

--- a/src/test/java/org/apache/commons/jxpath/ri/ExceptionHandlerTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/ExceptionHandlerTest.java
@@ -18,6 +18,10 @@ package org.apache.commons.jxpath.ri;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test simple ExceptionHandler.
@@ -33,6 +37,7 @@ public class ExceptionHandlerTest extends AbstractJXPathTest {
     private final Bar bar = new Bar();
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         context = JXPathContext.newContext(this);
         context.setExceptionHandler((t, ptr) -> {
@@ -50,6 +55,7 @@ public class ExceptionHandlerTest extends AbstractJXPathTest {
         throw new IllegalStateException("foo unavailable");
     }
 
+    @Test
     public void testHandleFoo() throws Exception {
         try {
             context.getValue("foo");
@@ -65,6 +71,7 @@ public class ExceptionHandlerTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testHandleBarBaz() throws Exception {
         try {
             context.getValue("bar/baz");

--- a/src/test/java/org/apache/commons/jxpath/ri/JXPathCompiledExpressionTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/JXPathCompiledExpressionTest.java
@@ -40,6 +40,9 @@ import org.apache.commons.jxpath.ri.compiler.ExtensionFunction;
 import org.apache.commons.jxpath.ri.compiler.LocationPath;
 import org.apache.commons.jxpath.ri.compiler.NameAttributeTest;
 import org.apache.commons.jxpath.ri.compiler.VariableReference;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test compiler.
@@ -47,12 +50,14 @@ import org.apache.commons.jxpath.ri.compiler.VariableReference;
 
 public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
 
+    @Test
     public void testConstant() {
         assertXPathExpression("1", Constant.class);
         assertXPathExpression("1.5", Constant.class);
         assertXPathExpression("'foo'", Constant.class);
     }
 
+    @Test
     public void testCoreFunction() {
         assertXPathExpression("last()", CoreFunction.class);
         assertXPathExpression("position()", CoreFunction.class);
@@ -90,73 +95,87 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
         assertXPathExpression("format-number(12, '##')", CoreFunction.class);
     }
 
+    @Test
     public void testCoreOperationAnd() {
         assertXPathExpression("2 and 4", CoreOperationAnd.class);
         assertXPathExpression("2 > 1 and 4 < 5", CoreOperationAnd.class);
     }
 
+    @Test
     public void testCoreOperationOr() {
         assertXPathExpression("2 or 4", CoreOperationOr.class);
         assertXPathExpression("2 > 1 or 4 < 5", CoreOperationOr.class);
         assertXPathExpression("1 > 1 and 2 <= 2 or 3 = 4", CoreOperationOr.class);
     }
 
+    @Test
     public void testCoreOperationEqual() {
         assertXPathExpression("2 = 4", CoreOperationEqual.class);
         assertXPathExpression("2 + 1 = 3", CoreOperationEqual.class);
     }
 
+    @Test
     public void testCoreOperationNameAttributeTest() {
         assertXPathExpression("@name = 'bar'", NameAttributeTest.class);
     }
 
+    @Test
     public void testCoreOperationNotEqual() {
         assertXPathExpression("2 != 4", CoreOperationNotEqual.class);
         assertXPathExpression("2 + 1 != 3", CoreOperationNotEqual.class);
     }
 
+    @Test
     public void testCoreOperationLessThan() {
         assertXPathExpression("3<4", CoreOperationLessThan.class, "3 < 4");
         assertXPathExpression("3<(2>=1)", CoreOperationLessThan.class, "3 < (2 >= 1)");
     }
 
+    @Test
     public void testCoreOperationLessThanOrEqual() {
         assertXPathExpression("3<=4", CoreOperationLessThanOrEqual.class, "3 <= 4");
         assertXPathExpression("3<=(2>=1)", CoreOperationLessThanOrEqual.class, "3 <= (2 >= 1)");
     }
 
+    @Test
     public void testCoreOperationGreaterThan() {
         assertXPathExpression("3>4", CoreOperationGreaterThan.class, "3 > 4");
         assertXPathExpression("3>(2>=1)", CoreOperationGreaterThan.class, "3 > (2 >= 1)");
         assertXPathExpression("1 > (1 and 2 <= (2 or 3) = 4)", CoreOperationGreaterThan.class);
     }
 
+    @Test
     public void testCoreOperationGreaterThanOrEqual() {
         assertXPathExpression("3>=4", CoreOperationGreaterThanOrEqual.class, "3 >= 4");
         assertXPathExpression("3>=(2>=1)", CoreOperationGreaterThanOrEqual.class, "3 >= (2 >= 1)");
     }
 
+    @Test
     public void testCoreOperationDivide() {
         assertXPathExpression("2 div 4", CoreOperationDivide.class);
         assertXPathExpression("2|3 div -3", CoreOperationDivide.class, "2 | 3 div -3");
     }
 
+    @Test
     public void testCoreOperationMod() {
         assertXPathExpression("2 mod 4", CoreOperationMod.class);
         assertXPathExpression("2|3 mod -3", CoreOperationMod.class, "2 | 3 mod -3");
     }
 
+    @Test
     public void testCoreOperationMultiply() {
         assertXPathExpression("2*4", CoreOperationMultiply.class, "2 * 4");
         assertXPathExpression("2*(3 + 1)", CoreOperationMultiply.class, "2 * (3 + 1)");
     }
 
+    @Test
     public void testCoreOperationMinus() {
         assertXPathExpression("1 - 1", CoreOperationSubtract.class);
         assertXPathExpression("1 - 1 - 2", CoreOperationSubtract.class);
         assertXPathExpression("1 - (1 - 2)", CoreOperationSubtract.class);
     }
 
+    @Test
     public void testCoreOperationSum() {
         assertXPathExpression("3 + 1 + 4", CoreOperationAdd.class);
         assertXPathExpression("(3 + 1) + 4", CoreOperationAdd.class, "3 + 1 + 4");
@@ -165,30 +184,36 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
         assertXPathExpression("2*-3 + -1", CoreOperationAdd.class, "2 * -3 + -1");
     }
 
+    @Test
     public void testCoreOperationUnaryMinus() {
         assertXPathExpression("-3", CoreOperationNegate.class);
         assertXPathExpression("-(3 + 1)", CoreOperationNegate.class);
     }
 
+    @Test
     public void testCoreOperationUnion() {
         assertXPathExpression("3 | 1 | 4", CoreOperationUnion.class);
     }
 
+    @Test
     public void testExpressionPath() {
         assertXPathExpression("$x/foo/bar", ExpressionPath.class);
         assertXPathExpression("(2 + 2)/foo/bar", ExpressionPath.class);
         assertXPathExpression("$x[3][2 + 2]/foo/bar", ExpressionPath.class);
     }
 
+    @Test
     public void testExtensionFunction() {
         assertXPathExpression("my:function(3, other.function())", ExtensionFunction.class);
     }
 
+    @Test
     public void testLocationPathAxisSelf() {
         assertXPathExpression("self::foo:bar", LocationPath.class);
         assertXPathExpression(".", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathAxisChild() {
         assertXPathExpression("child::foo:bar", LocationPath.class, "foo:bar");
         assertXPathExpression("foo:bar", LocationPath.class);
@@ -198,11 +223,13 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
         assertXPathExpression("foo:*", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathAxisParent() {
         assertXPathExpression("parent::foo:bar", LocationPath.class);
         assertXPathExpression("..", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathAxisAttribute() {
         assertXPathExpression("attribute::foo:bar", LocationPath.class, "@foo:bar");
         assertXPathExpression("@foo:bar", LocationPath.class);
@@ -211,16 +238,19 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
         assertXPathExpression("@*[last()]", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathAxisDescendant() {
         assertXPathExpression("descendant::foo:bar", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathAxisDescendantOrSelf() {
         assertXPathExpression("descendant-or-self::foo:bar", LocationPath.class);
         assertXPathExpression("//foo", LocationPath.class);
         assertXPathExpression("foo//bar", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathAxisOther() {
         assertXPathExpression("ancestor::foo:bar", LocationPath.class);
         assertXPathExpression("ancestor-or-self::foo:bar", LocationPath.class);
@@ -231,6 +261,7 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
         assertXPathExpression("following-sibling::foo:bar", LocationPath.class);
     }
 
+    @Test
     public void testLocationPathNodeTest() {
         assertXPathExpression("node()", LocationPath.class);
         assertXPathExpression("text()", LocationPath.class);
@@ -239,6 +270,7 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
         assertXPathExpression("processing-instruction('test')", LocationPath.class);
     }
 
+    @Test
     public void testVariableReference() {
         assertXPathExpression("$x", VariableReference.class);
         assertXPathExpression("$x:y", VariableReference.class);
@@ -252,8 +284,8 @@ public class JXPathCompiledExpressionTest extends AbstractJXPathTest {
     private void assertXPathExpression(final String xpath, final Class expectedClass, final String expected) {
         final JXPathCompiledExpression expression = (JXPathCompiledExpression) JXPathContext.compile(xpath);
 
-        assertEquals("Expression class for " + xpath, expectedClass, expression.getExpression().getClass());
-        assertEquals("Expression toString() for " + xpath, expected, expression.getExpression().toString());
+        assertEquals(expectedClass, expression.getExpression().getClass(), "Expression class for " + xpath);
+        assertEquals(expected, expression.getExpression().toString(), "Expression toString() for " + xpath);
     }
 
     private void assertXPathExpression(final String xpath, final Class expectedClass) {

--- a/src/test/java/org/apache/commons/jxpath/ri/JXPathContextReferenceImplTestCase.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/JXPathContextReferenceImplTestCase.java
@@ -19,13 +19,14 @@ package org.apache.commons.jxpath.ri;
 
 import org.apache.commons.jxpath.ri.model.container.ContainerPointerFactory;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class JXPathContextReferenceImplTestCase extends TestCase {
+public class JXPathContextReferenceImplTestCase {
 
     /**
      * https://issues.apache.org/jira/browse/JXPATH-166
      */
+    @Test
     public void testInit() {
         final ContainerPointerFactory factory = new ContainerPointerFactory();
         try {

--- a/src/test/java/org/apache/commons/jxpath/ri/StressTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/StressTest.java
@@ -18,12 +18,15 @@ package org.apache.commons.jxpath.ri;
 
 import org.apache.commons.jxpath.JXPathContext;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test thread safety.
  */
-public class StressTest extends TestCase {
+public class StressTest {
 
     private static final int THREAD_COUNT = 50;
     private static final int THREAD_DURATION = 1000;
@@ -31,6 +34,7 @@ public class StressTest extends TestCase {
     private static int count;
     private static Throwable exception;
 
+    @Test
     public void testThreads() throws Throwable {
         context = JXPathContext.newContext(null, Double.valueOf(100));
         final Thread[] threadArray = new Thread[THREAD_COUNT];
@@ -47,14 +51,14 @@ public class StressTest extends TestCase {
                 element.join();
             }
             catch (final InterruptedException e) {
-                assertTrue("Interrupted", false);
+                fail("Interrupted");
             }
         }
 
         if (exception != null) {
             throw exception;
         }
-        assertEquals("Test count", THREAD_COUNT * THREAD_DURATION, count);
+        assertEquals(THREAD_COUNT * THREAD_DURATION, count, "Test count");
     }
 
     private static final class StressRunnable implements Runnable {
@@ -66,7 +70,7 @@ public class StressTest extends TestCase {
                     final double sum =
                         ((Double) context.getValue("/ + " + random))
                             .doubleValue();
-                    assertEquals(100 + random, sum, 0.0001);
+                    assertEquals(0.0001, sum, 100 + random);
                     synchronized (context) {
                         count++;
                     }

--- a/src/test/java/org/apache/commons/jxpath/ri/axes/RecursiveAxesTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/axes/RecursiveAxesTest.java
@@ -18,6 +18,8 @@ package org.apache.commons.jxpath.ri.axes;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the protection mechanism that stops infinite recursion
@@ -29,6 +31,7 @@ public class RecursiveAxesTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         bean = new RecursiveBean("zero");
         final RecursiveBean bean1 = new RecursiveBean("one");
@@ -42,6 +45,7 @@ public class RecursiveAxesTest extends AbstractJXPathTest {
         context = JXPathContext.newContext(null, bean);
     }
 
+    @Test
     public void testInfiniteDescent() {
         // Existing scalar property
         assertXPathPointer(

--- a/src/test/java/org/apache/commons/jxpath/ri/axes/SimplePathInterpreterTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/axes/SimplePathInterpreterTest.java
@@ -35,14 +35,19 @@ import org.apache.commons.jxpath.ri.model.dom.DOMNodePointer;
 import org.apache.commons.jxpath.ri.model.dynamic.DynamicPointer;
 import org.apache.commons.jxpath.ri.model.dynamic.DynamicPropertyPointer;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class SimplePathInterpreterTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SimplePathInterpreterTest  {
 
     private TestBeanWithNode bean;
     private JXPathContext context;
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         bean = TestBeanWithNode.createTestBeanWithDOM();
         final HashMap submap = new HashMap();
@@ -66,6 +71,7 @@ public class SimplePathInterpreterTest extends TestCase {
         context.setFactory(new TestBeanFactory());
     }
 
+    @Test
     public void testDoStepNoPredicatesPropertyOwner() {
         // Existing scalar property
         assertValueAndPointer("/int",
@@ -157,6 +163,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "BbC");
     }
 
+    @Test
     public void testDoStepNoPredicatesStandard() {
         // Existing DOM node
         assertValueAndPointer("/vendor/location/address/city",
@@ -180,6 +187,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "BbMMMMn");
     }
 
+    @Test
     public void testDoStepPredicatesPropertyOwner() {
         // missingProperty[@name=foo]
         assertNullPointer("/foo[@name='foo']",
@@ -192,6 +200,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "Bn");
     }
 
+    @Test
     public void testDoStepPredicatesStandard() {
         // Looking for an actual XML attribute called "name"
         // nodeProperty/name[@name=value]
@@ -224,6 +233,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "BbMM");
     }
 
+    @Test
     public void testDoPredicateName() {
         // existingProperty[@name=existingProperty]
         assertValueAndPointer("/nestedBean[@name='int']",
@@ -360,6 +370,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "BbDdM");
     }
 
+    @Test
     public void testDoPredicatesStandard() {
         // bean/map/collection/node
         assertValueAndPointer("map[@name='Key3'][@name='fruitco']",
@@ -401,6 +412,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "BbMM");
     }
 
+    @Test
     public void testDoPredicateIndex() {
         // Existing dynamic property + existing property + index
         assertValueAndPointer("/map[@name='Key2'][@name='strings'][2]",
@@ -547,6 +559,7 @@ public class SimplePathInterpreterTest extends TestCase {
                 "BbB");
     }
 
+    @Test
     public void testInterpretExpressionPath() {
         context.getVariables().declareVariable("array", new String[]{"Value1"});
         context.getVariables().declareVariable("testnull", new TestNull());
@@ -573,36 +586,36 @@ public class SimplePathInterpreterTest extends TestCase {
             final String expectedSignature, final String expectedValueSignature)
     {
         final Object value = context.getValue(path);
-        assertEquals("Checking value: " + path, expectedValue, value);
+        assertEquals(expectedValue, value, "Checking value: " + path);
 
         final Pointer pointer = context.getPointer(path);
-        assertEquals("Checking pointer: " + path,
-                expectedPath, pointer.toString());
+        assertEquals(expectedPath, pointer.toString(),
+                "Checking pointer: " + path);
 
-        assertEquals("Checking signature: " + path,
-                expectedSignature, pointerSignature(pointer));
+        assertEquals(expectedSignature, pointerSignature(pointer),
+                "Checking signature: " + path);
 
         final Pointer vPointer = ((NodePointer) pointer).getValuePointer();
-        assertEquals("Checking value pointer signature: " + path,
-                expectedValueSignature, pointerSignature(vPointer));
+        assertEquals(expectedValueSignature, pointerSignature(vPointer),
+                "Checking value pointer signature: " + path);
     }
 
     private void assertNullPointer(final String path, final String expectedPath,
             final String expectedSignature)
     {
         final Pointer pointer = context.getPointer(path);
-        assertNotNull("Null path exists: " + path,
-                    pointer);
-        assertEquals("Null path as path: " + path,
-                    expectedPath, pointer.asPath());
-        assertEquals("Checking Signature: " + path,
-                    expectedSignature, pointerSignature(pointer));
+        assertNotNull(pointer,
+                "Null path exists: " + path);
+        assertEquals(expectedPath, pointer.asPath(),
+                "Null path as path: " + path);
+        assertEquals(expectedSignature, pointerSignature(pointer),
+                "Checking Signature: " + path);
 
         final Pointer vPointer = ((NodePointer) pointer).getValuePointer();
-        assertTrue("Null path is null: " + path,
-                    !((NodePointer) vPointer).isActual());
-        assertEquals("Checking value pointer signature: " + path,
-                    expectedSignature + "N", pointerSignature(vPointer));
+        assertFalse(((NodePointer) vPointer).isActual(),
+                "Null path is null: " + path);
+        assertEquals(expectedSignature + "N", pointerSignature(vPointer),
+                "Checking value pointer signature: " + path);
     }
 
     /**

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/ContextDependencyTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/ContextDependencyTest.java
@@ -18,12 +18,16 @@ package org.apache.commons.jxpath.ri.compiler;
 
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.ri.Parser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the determination of whether an expression is context dependent.
  */
 public class ContextDependencyTest extends AbstractJXPathTest {
 
+    @Test
     public void testContextDependency() {
         testContextDependency("1", false);
         testContextDependency("$x", false);
@@ -40,6 +44,6 @@ public class ContextDependencyTest extends AbstractJXPathTest {
     public void testContextDependency(final String xpath, final boolean expected) {
         final Expression expr = (Expression) Parser.parseExpression(xpath, new TreeCompiler());
 
-        assertEquals("Context dependency <" + xpath + ">", expected, expr.isContextDependent());
+        assertEquals(expected, expr.isContextDependent(), "Context dependency <" + xpath + ">");
     }
 }

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreFunctionTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreFunctionTest.java
@@ -28,6 +28,8 @@ import org.apache.commons.jxpath.Pointer;
 import org.apache.commons.jxpath.TestMixedModelBean;
 import org.apache.commons.jxpath.Variables;
 import org.apache.commons.jxpath.ri.model.NodePointer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test basic functionality of JXPath - core functions.
@@ -36,6 +38,7 @@ public class CoreFunctionTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         if (context == null) {
             context = JXPathContext.newContext(new TestMixedModelBean());
@@ -46,6 +49,7 @@ public class CoreFunctionTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testCoreFunctions() {
         assertXPathValue(context, "string(2)", "2");
         assertXPathValue(context, "string($nan)", "NaN");
@@ -116,6 +120,7 @@ public class CoreFunctionTest extends AbstractJXPathTest {
         assertXPathValue(context, "round(2 div 0)", Double.valueOf(Double.POSITIVE_INFINITY));
     }
 
+    @Test
     public void testIDFunction() {
         context.setIdentityManager((context, id) -> {
             NodePointer ptr = (NodePointer) context.getPointer("/document");
@@ -135,12 +140,14 @@ public class CoreFunctionTest extends AbstractJXPathTest {
             "id(105)/address/street");
     }
 
+    @Test
     public void testKeyFunction() {
         context.setKeyManager((context, key, value) -> NodePointer.newNodePointer(null, "42", null));
 
         assertXPathValue(context, "key('a', 'b')", "42");
     }
 
+    @Test
     public void testExtendedKeyFunction() {
         context.setKeyManager(new ExtendedKeyManager() {
             @Override
@@ -184,6 +191,7 @@ public class CoreFunctionTest extends AbstractJXPathTest {
         assertXPathValueIterator(context, "key('a', $ints)", list("53", "64", "53", "64"));
     }
 
+    @Test
     public void testFormatNumberFunction() {
 
         final DecimalFormatSymbols symbols = new DecimalFormatSymbols();

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreOperationTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreOperationTest.java
@@ -19,6 +19,8 @@ package org.apache.commons.jxpath.ri.compiler;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.Variables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test basic functionality of JXPath - infoset types,
@@ -28,6 +30,7 @@ public class CoreOperationTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         if (context == null) {
             context = JXPathContext.newContext(null);
@@ -38,6 +41,7 @@ public class CoreOperationTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testInfoSetTypes() {
 
         // Numbers
@@ -85,6 +89,7 @@ public class CoreOperationTest extends AbstractJXPathTest {
         assertXPathValue(context, "'true'", Boolean.TRUE, Boolean.class);
     }
 
+    @Test
     public void testNodeSetOperations() {
         assertXPathValue(context, "$array > 0", Boolean.TRUE, Boolean.class);
         assertXPathValue(context, "$array >= 0", Boolean.TRUE, Boolean.class);
@@ -100,6 +105,7 @@ public class CoreOperationTest extends AbstractJXPathTest {
         assertXPathValue(context, "$array < 0", Boolean.FALSE, Boolean.class);
     }
 
+    @Test
     public void testEmptyNodeSetOperations() {
         assertXPathValue(context, "/idonotexist = 0", Boolean.FALSE, Boolean.class);
         assertXPathValue(context, "/idonotexist != 0", Boolean.FALSE, Boolean.class);
@@ -115,6 +121,7 @@ public class CoreOperationTest extends AbstractJXPathTest {
         assertXPathValue(context, "$array[position() < 1] <= 0", Boolean.FALSE, Boolean.class);
     }
 
+    @Test
     public void testNan() {
         assertXPathValue(context, "$nan > $nan", Boolean.FALSE, Boolean.class);
         assertXPathValue(context, "$nan < $nan", Boolean.FALSE, Boolean.class);

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/VariableTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/VariableTest.java
@@ -20,6 +20,12 @@ import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.TestMixedModelBean;
 import org.apache.commons.jxpath.Variables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test basic functionality of JXPath - infoset types,
@@ -29,6 +35,7 @@ public class VariableTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         if (context == null) {
             context = JXPathContext.newContext(new TestMixedModelBean());
@@ -45,11 +52,13 @@ public class VariableTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testVariables() {
         // Variables
         assertXPathValueAndPointer(context, "$a", Double.valueOf(1), "$a");
     }
 
+    @Test
     public void testVariablesInExpressions() {
         assertXPathValue(context, "$a = $b", Boolean.TRUE);
 
@@ -62,6 +71,7 @@ public class VariableTest extends AbstractJXPathTest {
         assertXPathValue(context, "$d[2]", "b");
     }
 
+    @Test
     public void testInvalidVariableName() {
         boolean exception = false;
         try {
@@ -71,8 +81,8 @@ public class VariableTest extends AbstractJXPathTest {
             exception = true;
         }
         assertTrue(
-            "Evaluating '$none', expected exception - did not get it",
-            exception);
+            exception,
+            "Evaluating '$none', expected exception - did not get it");
 
         exception = false;
         try {
@@ -82,25 +92,29 @@ public class VariableTest extends AbstractJXPathTest {
             exception = true;
         }
         assertTrue(
-            "Setting '$none = 1', expected exception - did not get it",
-            exception);
+            exception,
+            "Setting '$none = 1', expected exception - did not get it");
     }
 
+    @Test
     public void testNestedContext() {
         final JXPathContext nestedContext = JXPathContext.newContext(context, null);
 
         assertXPathValue(nestedContext, "$a", Double.valueOf(1));
     }
 
+    @Test
     public void testSetValue() {
         assertXPathSetValue(context, "$x", Integer.valueOf(1));
     }
 
+    @Test
     public void testCreatePathDeclareVariable() {
         // Calls factory.declareVariable("string")
         assertXPathCreatePath(context, "$string", null, "$string");
     }
 
+    @Test
     public void testCreatePathAndSetValueDeclareVariable() {
         // Calls factory.declareVariable("string")
         assertXPathCreatePathAndSetValue(
@@ -110,6 +124,7 @@ public class VariableTest extends AbstractJXPathTest {
             "$string");
     }
 
+    @Test
     public void testCreatePathDeclareVariableSetCollectionElement() {
         // Calls factory.declareVariable("stringArray").
         // The factory needs to create a collection
@@ -121,11 +136,12 @@ public class VariableTest extends AbstractJXPathTest {
 
         // See if the factory populated the first element as well
         assertEquals(
-            "Created <" + "$stringArray[1]" + ">",
             "Value1",
-            context.getValue("$stringArray[1]"));
+            context.getValue("$stringArray[1]"),
+            "Created <" + "$stringArray[1]" + ">");
     }
 
+    @Test
     public void testCreateAndSetValuePathDeclareVariableSetCollectionElement() {
         // Calls factory.declareVariable("stringArray").
         // The factory needs to create a collection
@@ -137,11 +153,12 @@ public class VariableTest extends AbstractJXPathTest {
 
         // See if the factory populated the first element as well
         assertEquals(
-            "Created <" + "$stringArray[1]" + ">",
             "Value1",
-            context.getValue("$stringArray[1]"));
+            context.getValue("$stringArray[1]"),
+            "Created <" + "$stringArray[1]" + ">");
     }
 
+    @Test
     public void testCreatePathExpandCollection() {
         context.getVariables().declareVariable(
             "array",
@@ -152,11 +169,12 @@ public class VariableTest extends AbstractJXPathTest {
 
         // Make sure it is still the same array
         assertEquals(
-            "Created <" + "$array[1]" + ">",
             "Value1",
-            context.getValue("$array[1]"));
+            context.getValue("$array[1]"),
+            "Created <" + "$array[1]" + ">");
     }
 
+    @Test
     public void testCreatePathAndSetValueExpandCollection() {
         context.getVariables().declareVariable(
             "array",
@@ -171,11 +189,12 @@ public class VariableTest extends AbstractJXPathTest {
 
         // Make sure it is still the same array
         assertEquals(
-            "Created <" + "$array[1]" + ">",
             "Value1",
-            context.getValue("$array[1]"));
+            context.getValue("$array[1]"),
+            "Created <" + "$array[1]" + ">");
     }
 
+    @Test
     public void testCreatePathDeclareVariableSetProperty() {
         // Calls factory.declareVariable("test").
         // The factory should create a TestBean
@@ -187,6 +206,7 @@ public class VariableTest extends AbstractJXPathTest {
 
     }
 
+    @Test
     public void testCreatePathAndSetValueDeclareVariableSetProperty() {
         // Calls factory.declareVariable("test").
         // The factory should create a TestBean
@@ -198,6 +218,7 @@ public class VariableTest extends AbstractJXPathTest {
 
     }
 
+    @Test
     public void testCreatePathDeclareVariableSetCollectionElementProperty() {
         // Calls factory.declareVariable("testArray").
         // The factory should create a collection of TestBeans.
@@ -211,6 +232,7 @@ public class VariableTest extends AbstractJXPathTest {
             "$testArray[2]/boolean");
     }
 
+    @Test
     public void testCreatePathAndSetValueDeclVarSetCollectionElementProperty() {
         // Calls factory.declareVariable("testArray").
         // The factory should create a collection of TestBeans.
@@ -224,16 +246,18 @@ public class VariableTest extends AbstractJXPathTest {
             "$testArray[2]/boolean");
     }
 
+    @Test
     public void testRemovePathUndeclareVariable() {
         // Undeclare variable
         context.getVariables().declareVariable("temp", "temp");
         context.removePath("$temp");
-        assertTrue(
-            "Undeclare variable",
-            !context.getVariables().isDeclaredVariable("temp"));
+        assertFalse(
+            context.getVariables().isDeclaredVariable("temp"),
+            "Undeclare variable");
 
     }
 
+    @Test
     public void testRemovePathArrayElement() {
         // Remove array element - reassigns the new array to the var
         context.getVariables().declareVariable(
@@ -241,26 +265,29 @@ public class VariableTest extends AbstractJXPathTest {
             new String[] { "temp1", "temp2" });
         context.removePath("$temp[1]");
         assertEquals(
-            "Remove array element",
             "temp2",
-            context.getValue("$temp[1]"));
+            context.getValue("$temp[1]"),
+            "Remove array element");
     }
 
+    @Test
     public void testRemovePathCollectionElement() {
         // Remove list element - does not create a new list
         context.getVariables().declareVariable("temp", list("temp1", "temp2"));
         context.removePath("$temp[1]");
         assertEquals(
-            "Remove collection element",
             "temp2",
-            context.getValue("$temp[1]"));
+            context.getValue("$temp[1]"),
+            "Remove collection element");
     }
 
+    @Test
     public void testUnionOfVariableAndNode() throws Exception {
         assertXPathValue(context, "count($a | /document/vendor/location)", Double.valueOf(3));
         assertXPathValue(context, "count($a | /list)", Double.valueOf(7)); //$o + list which contains six discrete values (one is duped, wrapped in a Container)
     }
 
+    @Test
     public void testIterateVariable() throws Exception {
         assertXPathValueIterator(context, "$d", list("a", "b"));
         assertXPathValue(context, "$d = 'a'", Boolean.TRUE);

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AbstractBeanModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AbstractBeanModelTest.java
@@ -34,6 +34,12 @@ import org.apache.commons.jxpath.ri.compiler.TestFunctions;
 import org.apache.commons.jxpath.ri.model.beans.PropertyOwnerPointer;
 import org.apache.commons.jxpath.ri.model.beans.PropertyPointer;
 import org.apache.commons.jxpath.ri.model.dynabeans.DynaBeanModelTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract superclass for Bean access with JXPath.
@@ -42,6 +48,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
 //        if (context == null) {
             context = JXPathContext.newContext(createContextBean());
@@ -56,6 +63,8 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
     /**
      * Test property iterators, the core of the graph traversal engine
      */
+
+    @Test
     public void testIndividualIterators() {
         testIndividual(+1, 0, true, false, 0);
         testIndividual(-1, 0, true, false, 4);
@@ -105,21 +114,22 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             size++;
         }
         assertEquals(
+            expected,
+            size,
             "ITERATIONS: Individual, relativePropertyIndex="
                 + relativePropertyIndex
                 + ", offset="
                 + offset
-                + ", useStartLocation="
+                    + ", useStartLocation="
                 + useStartLocation
                 + ", reverse="
-                + reverse,
-            expected,
-            size);
+                + reverse);
     }
 
     /**
      * Test property iterators with multiple properties returned
      */
+    @Test
     public void testMultipleIterators() {
         testMultiple(0, 0, true, false, 20);
 
@@ -162,6 +172,8 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             size++;
         }
         assertEquals(
+            expected,
+            size,
             "ITERATIONS: Multiple, propertyIndex="
                 + propertyIndex
                 + ", offset="
@@ -169,9 +181,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
                 + ", useStartLocation="
                 + useStartLocation
                 + ", reverse="
-                + reverse,
-            expected,
-            size);
+                + reverse);
     }
 
     private int relativeProperty(final PropertyPointer holder, final int offset) {
@@ -184,6 +194,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         return -1;
     }
 
+    @Test
     public void testIteratePropertyArrayWithHasNext() {
         final JXPathContext context = JXPathContext.newContext(createContextBean());
         final Iterator<Pointer> it = context.iteratePointers("/integers");
@@ -192,15 +203,16 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             actual.add(it.next().asPath());
         }
         assertEquals(
-            "Iterating 'hasNext'/'next'<" + "/integers" + ">",
             list(
                 "/integers[1]",
                 "/integers[2]",
                 "/integers[3]",
                 "/integers[4]"),
-            actual);
+            actual,
+            "Iterating 'hasNext'/'next'<" + "/integers" + ">");
     }
 
+    @Test
     public void testIteratePropertyArrayWithoutHasNext() {
         final JXPathContext context = JXPathContext.newContext(createContextBean());
         final Iterator<Pointer> it = context.iteratePointers("/integers");
@@ -209,15 +221,16 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             actual.add(it.next().toString());
         }
         assertEquals(
-            "Iterating 'next'<" + "/integers" + ">",
             list(
                 "/integers[1]",
                 "/integers[2]",
                 "/integers[3]",
                 "/integers[4]"),
-            actual);
+            actual,
+            "Iterating 'next'<" + "/integers" + ">");
     }
 
+    @Test
     public void testIterateAndSet() {
         final JXPathContext context = JXPathContext.newContext(createContextBean());
 
@@ -234,14 +247,15 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             actual.add(it.next().getValue());
         }
         assertEquals(
-            "Iterating <" + "beans/int" + ">",
             list(Integer.valueOf(5), Integer.valueOf(6)),
-            actual);
+            actual,
+            "Iterating <" + "beans/int" + ">");
     }
 
     /**
      * Test contributed by Kate Dvortsova
      */
+    @Test
     public void testIteratePointerSetValue() {
         final JXPathContext context = JXPathContext.newContext(createContextBean());
 
@@ -264,23 +278,25 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             String s = (String) pointer.getValue();
             s += "suffix";
             pointer.setValue(s);
-            assertEquals("pointer.getValue", s, pointer.getValue());
+            assertEquals(s, pointer.getValue(),"pointer.getValue");
             // fails right here, the value isn't getting set in the bean.
             assertEquals(
-                "context.getValue",
                 s,
-                context.getValue(pointer.asPath()));
+                context.getValue(pointer.asPath()),
+                "context.getValue");
         }
-        assertEquals("Iteration count", 2, iterCount);
+        assertEquals(2, iterCount, "Iteration count");
 
         assertXPathValue(context, "/beans[1]/name", "Name 1suffix");
         assertXPathValue(context, "/beans[2]/name", "Name 2suffix");
     }
 
+    @Test
     public void testRoot() {
         assertXPathValueAndPointer(context, "/", context.getContextBean(), "/");
     }
 
+    @Test
     public void testAxisAncestor() {
         // ancestor::
         assertXPathValue(context, "int/ancestor::root = /", Boolean.TRUE);
@@ -296,6 +312,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Boolean.TRUE);
     }
 
+    @Test
     public void testAxisChild() {
         assertXPathValue(context, "boolean", Boolean.FALSE);
 
@@ -318,6 +335,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "count(child::node())", Double.valueOf(21));
     }
 
+    @Test
     public void testAxisChildNestedBean() {
         // Nested bean
         assertXPathValue(context, "nestedBean/name", "Name 0");
@@ -330,6 +348,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             list("/nestedBean/name"));
     }
 
+    @Test
     public void testAxisChildNestedCollection() {
         assertXPathValueIterator(
             context,
@@ -352,6 +371,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
                 "/integers[4]"));
     }
 
+    @Test
     public void testIndexPredicate() {
         assertXPathValue(context, "integers[2]", Integer.valueOf(2));
 
@@ -383,6 +403,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "(beans/strings[2])[1]", "String 2");
     }
 
+    @Test
     public void testAxisDescendant() {
         // descendant::
         assertXPathValue(context, "count(descendant::node())", Double.valueOf(65));
@@ -393,6 +414,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "count(descendant::name)", Double.valueOf(7));
     }
 
+    @Test
     public void testAxisDescendantOrSelf() {
         // descendant-or-self::
         assertXPathValueIterator(
@@ -440,6 +462,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
 
     }
 
+    @Test
     public void testAxisFollowing() {
         // following::
         assertXPathValue(
@@ -453,6 +476,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Double.valueOf(7));
     }
 
+    @Test
     public void testAxisFollowingSibling() {
         // following-sibling::
         assertXPathValue(
@@ -488,6 +512,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Double.valueOf(7));
     }
 
+    @Test
     public void testAxisParent() {
         // parent::
         assertXPathValue(context, "count(/beans/..)", Double.valueOf(1));
@@ -502,6 +527,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             list("Name 1", "Name 2"));
     }
 
+    @Test
     public void testAxisPreceding() {
         // preceding::
         assertXPathValue(
@@ -515,6 +541,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Double.valueOf(2));
     }
 
+    @Test
     public void testAxisPrecedingSibling() {
         // preceding-sibling::
         assertXPathValue(
@@ -533,6 +560,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Double.valueOf(10));
     }
 
+    @Test
     public void testAxisSelf() {
         // self::
         assertXPathValue(context, "self::node() = /", Boolean.TRUE);
@@ -540,6 +568,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "self::root = /", Boolean.TRUE);
     }
 
+    @Test
     public void testUnion() {
         // Union - note corrected document order
         assertXPathValueIterator(
@@ -569,6 +598,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "(integers)[2]", Integer.valueOf(2));
     }
 
+    @Test
     public void testAxisAttribute() {
         // Attributes are just like children to beans
         assertXPathValue(context, "count(@*)", Double.valueOf(21.0));
@@ -581,6 +611,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
      * Testing the pseudo-attribute "name" that java beans
      * objects appear to have.
      */
+    @Test
     public void testAttributeName() {
         assertXPathValue(context, "nestedBean[@name = 'int']", Integer.valueOf(1));
 
@@ -590,6 +621,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/nestedBean/int");
     }
 
+    @Test
     public void testAttributeLang() {
 
         assertXPathValue(context, "@xml:lang", "en-US");
@@ -601,6 +633,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "lang('fr')", Boolean.FALSE);
     }
 
+    @Test
     public void testCoreFunctions() {
 
         assertXPathValue(context, "boolean(boolean)", Boolean.TRUE);
@@ -632,6 +665,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
                 "/beans[1]/strings[3]");
     }
 
+    @Test
     public void testBooleanPredicate() {
         // use child axis
 
@@ -705,6 +739,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             list(Integer.valueOf(1)));
     }
 
+    @Test
     public void testDocumentOrder() {
         assertDocumentOrder(context, "boolean", "int", -1);
 
@@ -723,6 +758,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertDocumentOrder(context, "nestedBean/int", "object/int", -1);
     }
 
+    @Test
     public void testSetPropertyValue() {
         // Simple property
         assertXPathSetValue(context, "int", Integer.valueOf(2));
@@ -737,6 +773,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathSetValue(context, "@int", Integer.valueOf(10));
     }
 
+    @Test
     public void testSetCollectionElement() {
         // Collection element
         assertXPathSetValue(context, "integers[2]", Integer.valueOf(5));
@@ -749,6 +786,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Integer.valueOf(6));
     }
 
+    @Test
     public void testSetContextDependentNode() {
         // Find node without using SimplePathInterpreter
         assertXPathSetValue(
@@ -764,6 +802,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
 
     }
 
+    @Test
     public void testSetNonPrimitiveValue() {
         // First, let's see if we can set a collection element to null
         assertXPathSetValue(context, "beans[2]", null);
@@ -772,11 +811,12 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         context.setValue("beans[2]", new NestedTestBean("Name 9"));
 
         assertEquals(
-            "Modified <" + "beans[2]/name" + ">",
             "Name 9",
-            context.getValue("beans[2]/name"));
+            context.getValue("beans[2]/name"),
+            "Modified <" + "beans[2]/name" + ">");
     }
 
+    @Test
     public void testCreatePath() {
         context.setValue("nestedBean", null);
 
@@ -798,10 +838,11 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         catch (final Exception e) {
             ex = true;
         }
-        assertTrue("Exception thrown on invalid path for creation", ex);
+        assertTrue(ex, "Exception thrown on invalid path for creation");
 
     }
 
+    @Test
     public void testCreatePathAndSetValue() {
         context.setValue("nestedBean", null);
 
@@ -813,6 +854,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/nestedBean/int");
     }
 
+    @Test
     public void testCreatePathExpandNewCollection() {
         context.setValue("beans", null);
 
@@ -825,6 +867,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/beans[2]/int");
     }
 
+    @Test
     public void testCreatePathAndSetValueExpandNewCollection() {
         context.setValue("beans", null);
 
@@ -837,6 +880,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/beans[2]/int");
     }
 
+    @Test
     public void testCreatePathExpandExistingCollection() {
         // Calls factory.createObject(..., TestBean, "integers", 5)
         // to expand collection
@@ -847,6 +891,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/integers[5]");
     }
 
+    @Test
     public void testCreatePathExpandExistingCollectionAndSetProperty() {
         // Another, but the collection already exists
         assertXPathCreatePath(
@@ -856,6 +901,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/beans[3]/int");
     }
 
+    @Test
     public void testCreatePathAndSetValueExpandExistingCollection() {
         // Another, but the collection already exists
         assertXPathCreatePathAndSetValue(
@@ -865,6 +911,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/beans[3]/int");
     }
 
+    @Test
     public void testCreatePathCreateBeanExpandCollection() {
         context.setValue("nestedBean", null);
 
@@ -877,6 +924,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/nestedBean/strings[2]");
     }
 
+    @Test
     public void testCreatePathAndSetValueCreateBeanExpandCollection() {
         context.setValue("nestedBean", null);
 
@@ -889,24 +937,27 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/nestedBean/strings[2]");
     }
 
+    @Test
     public void testRemovePathPropertyValue() {
         // Remove property value
         context.removePath("nestedBean/int");
         assertEquals(
-            "Remove property value",
             Integer.valueOf(0),
-            context.getValue("nestedBean/int"));
+            context.getValue("nestedBean/int"),
+            "Remove property value");
     }
 
+    @Test
     public void testRemovePathArrayElement() {
         // Assigns a new array to the property
         context.removePath("nestedBean/strings[1]");
         assertEquals(
-            "Remove array element",
             "String 2",
-            context.getValue("nestedBean/strings[1]"));
+            context.getValue("nestedBean/strings[1]"),
+            "Remove array element");
     }
 
+    @Test
     public void testRemoveAllArrayElements() {
         context.removeAll("nestedBean/strings");
         assertXPathValueIterator(
@@ -915,6 +966,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             list());
     }
 
+    @Test
     public void testRemoveAllListElements() {
         context.removeAll("list");
         assertXPathValueIterator(
@@ -923,6 +975,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             this instanceof DynaBeanModelTest ? list(null, null, null) : list());
     }
 
+    @Test
     public void testRemoveAllMapEntries() {
         context.removeAll("map/*");
         assertXPathValue(
@@ -931,14 +984,15 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Collections.EMPTY_MAP);
     }
 
+    @Test
     public void testRemovePathBeanValue() {
         context.removePath("nestedBean");
-        assertEquals(
-            "Remove collection element",
-            null,
-            context.getValue("nestedBean"));
+        assertNull(
+            context.getValue("nestedBean"),
+            "Remove collection element");
     }
 
+    @Test
     public void testRelativeContextRelativePath() {
         final JXPathContext relative =
             context.getRelativeContext(context.getPointer("nestedBean"));
@@ -949,6 +1003,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/nestedBean/int");
     }
 
+    @Test
     public void testRelativeContextAbsolutePath() {
         final JXPathContext relative =
             context.getRelativeContext(context.getPointer("nestedBean"));
@@ -959,6 +1014,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/integers[2]");
     }
 
+    @Test
     public void testRelativeContextParent() {
         final JXPathContext relative =
             context.getRelativeContext(context.getPointer("nestedBean"));
@@ -969,6 +1025,7 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             "/integers[2]");
     }
 
+    @Test
     public void testRelativeContextInheritance() {
         context.setFunctions(new ClassFunctions(TestFunctions.class, "test"));
         final JXPathContext relative =

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AbstractXMLModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AbstractXMLModelTest.java
@@ -23,6 +23,12 @@ import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.Pointer;
 import org.apache.commons.jxpath.Variables;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Abstract superclass for pure XPath 1.0.  Subclasses
@@ -34,6 +40,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
     protected JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         if (context == null) {
             final DocumentContainer docCtr = createDocumentContainer();
@@ -86,9 +93,10 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
     {
         final Object node = context.getPointer(path).getNode();
         final String sig = getXMLSignature(node, elements, attributes, text, pi);
-        assertEquals("XML Signature mismatch: ", signature, sig);
+        assertEquals(signature, sig, "XML Signature mismatch: ");
     }
 
+    @Test
     public void testDocumentOrder() {
         assertDocumentOrder(
             context,
@@ -109,6 +117,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             1);
     }
 
+    @Test
     public void testSetValue() {
         assertXPathSetValue(
             context,
@@ -142,6 +151,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
     /**
      * Test JXPathContext.createPath() with various arguments
      */
+    @Test
     public void testCreatePath() {
         // Create a DOM element
         assertXPathCreatePath(
@@ -189,6 +199,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
     /**
      * Test JXPath.createPathAndSetValue() with various arguments
      */
+    @Test
     public void testCreatePathAndSetValue() {
         // Create a XML element
         assertXPathCreatePathAndSetValue(
@@ -242,27 +253,29 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
     /**
      * Test JXPathContext.removePath() with various arguments
      */
+    @Test
     public void testRemovePath() {
         // Remove XML nodes
         context.removePath("vendor/location[@id = '101']//street/text()");
         assertEquals(
-            "Remove DOM text",
             "",
-            context.getValue("vendor/location[@id = '101']//street"));
+            context.getValue("vendor/location[@id = '101']//street"),
+            "Remove DOM text");
 
         context.removePath("vendor/location[@id = '101']//street");
         assertEquals(
-            "Remove DOM element",
             Double.valueOf(0),
-            context.getValue("count(vendor/location[@id = '101']//street)"));
+            context.getValue("count(vendor/location[@id = '101']//street)"),
+            "Remove DOM element");
 
         context.removePath("vendor/location[@id = '100']/@name");
         assertEquals(
-            "Remove DOM attribute",
             Double.valueOf(0),
-            context.getValue("count(vendor/location[@id = '100']/@name)"));
+            context.getValue("count(vendor/location[@id = '100']/@name)"),
+            "Remove DOM attribute");
     }
 
+    @Test
     public void testID() {
         context.setIdentityManager((context, id) -> {
             NodePointer ptr = (NodePointer) context.getPointer("/");
@@ -282,6 +295,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "id(105)/address/street");
     }
 
+    @Test
     public void testAxisChild() {
         assertXPathValue(
             context,
@@ -334,7 +348,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         catch (final JXPathException ex) {
             nsv = true;
         }
-        assertTrue("No such value: /vendor/contact[@name='jim']", nsv);
+        assertTrue(nsv, "No such value: /vendor/contact[@name='jim']");
 
         nsv = false;
         try {
@@ -344,7 +358,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         catch (final JXPathException ex) {
             nsv = true;
         }
-        assertTrue("No such value: /vendor/contact[@name='jane']/*", nsv);
+        assertTrue(nsv, "No such value: /vendor/contact[@name='jane']/*");
 
         // child:: with a wildcard
         assertXPathValue(
@@ -363,6 +377,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "vendor/x:pos//number", "109");
     }
 
+    @Test
     public void testAxisChildIndexPredicate() {
         assertXPathValue(
             context,
@@ -370,6 +385,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "Tangerine Drive");
     }
 
+    @Test
     public void testAxisDescendant() {
         // descendant::
         assertXPathValue(context, "//street", "Orchard Road");
@@ -391,7 +407,8 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "vendor//promotion[../@stores = 'all']",
             list(""));
     }
-
+//
+//    @Test
 //    public void testAxisDescendantDocumentOrder() {
 //        Iterator iter = context.iteratePointers("//*");
 //        while (iter.hasNext()) {
@@ -399,6 +416,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
 //        }
 //    }
 
+    @Test
     public void testAxisParent() {
         // parent::
         assertXPathPointer(
@@ -421,6 +439,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "never");
     }
 
+    @Test
     public void testAxisFollowingSibling() {
         // following-sibling::
         assertXPathValue(
@@ -437,6 +456,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "/vendor[1]/location[2]/address[1]/street[1]");
     }
 
+    @Test
     public void testAxisPrecedingSibling() {
         // preceding-sibling:: produces the correct pointer
         assertXPathPointer(
@@ -445,6 +465,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "/vendor[1]/location[1]/address[1]/street[1]");
     }
 
+    @Test
     public void testAxisPreceding() {
         // preceding::
         assertXPathPointer(
@@ -456,6 +477,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         assertXPathPointer(context, "//location[2]/preceding::node()[4]", "/vendor[1]/location[1]/employeeCount[1]");
     }
 
+    @Test
     public void testAxisAttribute() {
         // attribute::
         assertXPathValue(context, "vendor/location/@id", "100");
@@ -573,6 +595,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "local"));
     }
 
+    @Test
     public void testAxisNamespace() {
         // namespace::
         assertXPathValueAndPointer(
@@ -600,6 +623,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "price");
     }
 
+    @Test
     public void testAxisAncestor() {
         // ancestor::
         assertXPathValue(
@@ -616,6 +640,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "never");
     }
 
+    @Test
     public void testAxisAncestorOrSelf() {
         // ancestor-or-self::
         assertXPathValue(
@@ -625,6 +650,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "never");
     }
 
+    @Test
     public void testAxisFollowing() {
         assertXPathValueIterator(
             context,
@@ -639,6 +665,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         assertXPathPointer(context, "//location[2]/following::node()[2]", "/vendor[1]/product[1]");
     }
 
+    @Test
     public void testAxisSelf() {
         // self:: with a namespace
         assertXPathValue(
@@ -650,6 +677,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         assertXPathValueLenient(context, "//price:sale/self::x/saleEnds", null);
     }
 
+    @Test
     public void testNodeTypeComment() {
         // comment()
         assertXPathValue(
@@ -658,6 +686,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "We are not buying this product, ever");
     }
 
+    @Test
     public void testNodeTypeText() {
         // text()
         //Note that this is questionable as the XPath spec tells us "." is short for self::node() and text() is by definition _not_ a node:
@@ -674,6 +703,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
 
     }
 
+    @Test
     public void testNodeTypeProcessingInstruction() {
         // processing-instruction() without an argument
         assertXPathValue(
@@ -700,6 +730,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "security");
     }
 
+    @Test
     public void testLang() {
         // xml:lang built-in attribute
         assertXPathValue(context, "//product/prix/@xml:lang", "fr");
@@ -714,6 +745,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             "never");
     }
 
+    @Test
     public void testDocument() {
         assertXPathValue(
             context,
@@ -728,6 +760,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "$document/vendor//street", "Orchard Road");
     }
 
+    @Test
     public void testContainer() {
         assertXPathValue(context, "$container/vendor//street", "Orchard Road");
 
@@ -745,10 +778,12 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             Double.valueOf(10));
     }
 
+    @Test
     public void testElementInVariable() {
         assertXPathValue(context, "$element", "Orchard Road");
     }
 
+    @Test
     public void testTypeConversions() {
         // Implicit conversion to number
         assertXPathValue(
@@ -763,6 +798,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             Boolean.TRUE);
     }
 
+    @Test
     public void testBooleanFunction() {
         assertXPathValue(
             context,
@@ -780,6 +816,7 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
             Boolean.FALSE);
     }
 
+    @Test
     public void testFunctionsLastAndPosition() {
         assertXPathPointer(
                 context,
@@ -787,17 +824,20 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
                 "/vendor[1]/location[2]");
     }
 
+    @Test
     public void testNamespaceMapping() {
         context.registerNamespace("rate", "priceNS");
         context.registerNamespace("goods", "productNS");
 
-        assertEquals("Context node namespace resolution",
+        assertEquals(
                 "priceNS",
-                context.getNamespaceURI("price"));
+                context.getNamespaceURI("price"),
+                "Context node namespace resolution");
 
-        assertEquals("Registered namespace resolution",
+        assertEquals(
                 "priceNS",
-                context.getNamespaceURI("rate"));
+                context.getNamespaceURI("rate"),
+                "Registered namespace resolution");
 
         // child:: with a namespace and wildcard
         assertXPathValue(context,
@@ -836,13 +876,15 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
                 "/vendor[1]/product[1]/goods:name[1]");
     }
 
+    @Test
     public void testUnion() {
         assertXPathValue(context, "/vendor[1]/contact[1] | /vendor[1]/contact[4]", "John");
         assertXPathValue(context, "/vendor[1]/contact[4] | /vendor[1]/contact[1]", "John");
     }
 
+    @Test
     public void testNodes() {
         final Pointer pointer = context.getPointer("/vendor[1]/contact[1]");
-        assertFalse(pointer.getNode().equals(pointer.getValue()));
+        assertNotEquals(pointer.getNode(), pointer.getValue());
     }
 }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AliasedNamespaceIterationTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AliasedNamespaceIterationTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test aliased/doubled XML namespace iteration; JXPATH-125.
@@ -48,10 +49,12 @@ public class AliasedNamespaceIterationTest extends AbstractJXPathTest {
         assertXPathPointerIterator(createContext(model), "/a:doc/a:elem", list("/a:doc[1]/a:elem[1]", "/a:doc[1]/a:elem[2]"));
     }
 
+    @Test
     public void testIterateDOM() {
         doTestIterate(DocumentContainer.MODEL_DOM);
     }
 
+    @Test
     public void testIterateJDOM() {
         doTestIterate(DocumentContainer.MODEL_JDOM);
     }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/EmbeddedColonMapKeysTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/EmbeddedColonMapKeysTest.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JXPATH-104 test.
@@ -28,6 +30,7 @@ public class EmbeddedColonMapKeysTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         final HashMap m = new HashMap();
@@ -36,11 +39,13 @@ public class EmbeddedColonMapKeysTest extends AbstractJXPathTest {
         context.setLenient(true);
     }
 
+    @Test
     public void testSelectNodes() throws Exception {
         assertXPathValueIterator(context, "/.[@name='foo:key']", list("value"));
         assertXPathValueIterator(context, "/foo:key", list());
     }
 
+    @Test
     public void testSelectSingleNode() throws Exception {
         assertXPathValue(context, "/.[@name='foo:key']", "value");
         assertXPathValueLenient(context, "/foo:key", null);

--- a/src/test/java/org/apache/commons/jxpath/ri/model/EmptyCollectionTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/EmptyCollectionTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * Be sure empty lists/sets/arrays work.
@@ -40,30 +41,36 @@ public class EmptyCollectionTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testEmptyList() {
         assertXPathPointerIterator(JXPathContext.newContext(Collections.EMPTY_LIST), "/*",
                 Collections.EMPTY_LIST);
     }
 
+    @Test
     public void testEmptyArray() {
         assertXPathPointerIterator(JXPathContext.newContext(new Object[0]), "/*", list());
     }
 
+    @Test
     public void testEmptySet() {
         assertXPathPointerIterator(JXPathContext.newContext(Collections.EMPTY_SET), "/*",
                 Collections.EMPTY_SET);
     }
 
+    @Test
     public void testEmptyChildList() {
         assertXPathPointerIterator(JXPathContext.newContext(new HasChild(Collections.EMPTY_LIST)),
                 "/child/*", Collections.EMPTY_LIST);
     }
 
+    @Test
     public void testEmptyChildArray() {
         assertXPathPointerIterator(JXPathContext.newContext(new HasChild(new Object[0])),
                 "/child/*", list());
     }
 
+    @Test
     public void testEmptyChildSet() {
         assertXPathPointerIterator(JXPathContext.newContext(new HasChild(Collections.EMPTY_SET)),
                 "/child/*", Collections.EMPTY_SET);

--- a/src/test/java/org/apache/commons/jxpath/ri/model/ExternalXMLNamespaceTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/ExternalXMLNamespaceTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.jxpath.ri.model;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test externally registered XML namespaces; JXPATH-97.
@@ -59,14 +60,17 @@ public class ExternalXMLNamespaceTest extends AbstractJXPathTest {
                 "/ElementA/@A:newAttr", "newValue", "/ElementA[1]/@A:newAttr");
     }
 
+    @Test
     public void testAttributeDOM() {
         doTestAttribute(DocumentContainer.MODEL_DOM);
     }
 
+    @Test
     public void testElementDOM() {
         doTestElement(DocumentContainer.MODEL_DOM);
     }
 
+    @Test
     public void testCreateAndSetAttributeDOM() {
         doTestCreateAndSetAttribute(DocumentContainer.MODEL_DOM);
     }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/JXPath151Test.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/JXPath151Test.java
@@ -22,12 +22,15 @@ import java.util.Locale;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.TestBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JXPath151Test extends AbstractJXPathTest {
 
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         final TestBean testBean = new TestBean();
         final HashMap m = new HashMap();
@@ -40,6 +43,7 @@ public class JXPath151Test extends AbstractJXPathTest {
         context.setLocale(Locale.US);
     }
 
+    @Test
     public void testMapValueEquality() {
         assertXPathValue(context, "map/b != map/a", Boolean.TRUE);
         assertXPathValue(context, "map/a != map/b", Boolean.TRUE);
@@ -50,6 +54,7 @@ public class JXPath151Test extends AbstractJXPathTest {
         assertXPathValue(context, "not(map/a = map/c)", Boolean.FALSE);
     }
 
+    @Test
     public void testMapValueEqualityUsingNameAttribute() {
         assertXPathValue(context, "map[@name = 'b'] != map[@name = 'c']", Boolean.TRUE);
         assertXPathValue(context, "map[@name = 'a'] != map[@name = 'b']", Boolean.TRUE);

--- a/src/test/java/org/apache/commons/jxpath/ri/model/JXPath154Test.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/JXPath154Test.java
@@ -20,6 +20,9 @@ package org.apache.commons.jxpath.ri.model;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JXPath154Test extends AbstractJXPathTest {
 
@@ -34,10 +37,12 @@ public class JXPath154Test extends AbstractJXPathTest {
         assertEquals(expectedValue, context.getPointer(path).asPath());
     }
 
+    @Test
     public void testInnerEmptyNamespaceDOM() {
         doTest("b:foo/test", DocumentContainer.MODEL_DOM, "/b:foo[1]/test[1]");
     }
 
+    @Test
     public void testInnerEmptyNamespaceJDOM() {
         doTest("b:foo/test", DocumentContainer.MODEL_JDOM, "/b:foo[1]/test[1]");
     }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/MixedModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/MixedModelTest.java
@@ -32,6 +32,11 @@ import org.apache.commons.jxpath.TestBean;
 import org.apache.commons.jxpath.TestMixedModelBean;
 import org.apache.commons.jxpath.TestNull;
 import org.apache.commons.jxpath.Variables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests JXPath with mixed model: beans, maps, DOM etc.
@@ -40,6 +45,7 @@ public class MixedModelTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         final TestMixedModelBean bean = new TestMixedModelBean();
         context = JXPathContext.newContext(bean);
@@ -61,6 +67,7 @@ public class MixedModelTest extends AbstractJXPathTest {
         vars.declareVariable("matrix", matrix);
     }
 
+    @Test
     public void testVar() {
         context.getVariables().declareVariable("foo:bar", "baz");
 
@@ -71,10 +78,12 @@ public class MixedModelTest extends AbstractJXPathTest {
 
     }
 
+    @Test
     public void testVarPrimitive() {
         assertXPathValueAndPointer(context, "$string", "string", "$string");
     }
 
+    @Test
     public void testVarBean() {
         assertXPathValueAndPointer(
             context,
@@ -83,6 +92,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "$bean/int");
     }
 
+    @Test
     public void testVarMap() {
         assertXPathValueAndPointer(
             context,
@@ -91,10 +101,12 @@ public class MixedModelTest extends AbstractJXPathTest {
             "$map[@name='string']");
     }
 
+    @Test
     public void testVarList() {
         assertXPathValueAndPointer(context, "$list[1]", "string", "$list[1]");
     }
 
+    @Test
     public void testVarDocument() {
         assertXPathValueAndPointer(
             context,
@@ -103,6 +115,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "$document/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testVarElement() {
         assertXPathValueAndPointer(
             context,
@@ -111,6 +124,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "$element/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testVarContainer() {
         assertXPathValueAndPointer(
             context,
@@ -119,10 +133,12 @@ public class MixedModelTest extends AbstractJXPathTest {
             "$container/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testBeanPrimitive() {
         assertXPathValueAndPointer(context, "string", "string", "/string");
     }
 
+    @Test
     public void testBeanBean() {
         assertXPathValueAndPointer(
             context,
@@ -131,6 +147,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/bean/int");
     }
 
+    @Test
     public void testBeanMap() {
         assertXPathValueAndPointer(
             context,
@@ -139,10 +156,12 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/map[@name='string']");
     }
 
+    @Test
     public void testBeanList() {
         assertXPathValueAndPointer(context, "list[1]", "string", "/list[1]");
     }
 
+    @Test
     public void testBeanDocument() {
         assertXPathValueAndPointer(
             context,
@@ -151,6 +170,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/document/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testBeanElement() {
         assertXPathValueAndPointer(
             context,
@@ -159,6 +179,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/element/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testBeanContainer() {
         assertXPathValueAndPointer(
             context,
@@ -167,6 +188,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/container/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testMapPrimitive() {
         assertXPathValueAndPointer(
             context,
@@ -175,6 +197,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/map[@name='string']");
     }
 
+    @Test
     public void testMapBean() {
         assertXPathValueAndPointer(
             context,
@@ -183,6 +206,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/map[@name='bean']/int");
     }
 
+    @Test
     public void testMapMap() {
         assertXPathValueAndPointer(
             context,
@@ -191,6 +215,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/map[@name='map'][@name='string']");
     }
 
+    @Test
     public void testMapList() {
         assertXPathValueAndPointer(
             context,
@@ -199,6 +224,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/map[@name='list'][1]");
     }
 
+    @Test
     public void testMapDocument() {
         assertXPathValueAndPointer(
             context,
@@ -208,6 +234,7 @@ public class MixedModelTest extends AbstractJXPathTest {
                 + "/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testMapElement() {
         assertXPathValueAndPointer(
             context,
@@ -216,6 +243,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/map[@name='element']/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testMapContainer() {
         assertXPathValueAndPointer(
             context,
@@ -225,10 +253,12 @@ public class MixedModelTest extends AbstractJXPathTest {
                 + "/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testListPrimitive() {
         assertXPathValueAndPointer(context, "list[1]", "string", "/list[1]");
     }
 
+    @Test
     public void testListBean() {
         assertXPathValueAndPointer(
             context,
@@ -237,6 +267,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/list[2]/int");
     }
 
+    @Test
     public void testListMap() {
         assertXPathValueAndPointer(
             context,
@@ -245,6 +276,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/list[3][@name='string']");
     }
 
+    @Test
     public void testListList() {
         /** @todo: what is this supposed to do? Should we stick to XPath,
          *  in which case [1] is simply ignored, or Java, in which case
@@ -262,6 +294,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/list[4]/.[1]");
     }
 
+    @Test
     public void testListDocument() {
         assertXPathValueAndPointer(
             context,
@@ -270,6 +303,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/list[5]/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testListElement() {
         assertXPathValueAndPointer(
             context,
@@ -278,6 +312,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/list[6]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testListContainer() {
         assertXPathValueAndPointer(
             context,
@@ -286,6 +321,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             "/list[7]/vendor[1]/location[2]/address[1]/city[1]");
     }
 
+    @Test
     public void testNull() {
 
         assertXPathPointerLenient(context, "$null", "$null");
@@ -321,10 +357,12 @@ public class MixedModelTest extends AbstractJXPathTest {
         assertXPathValueLenient(ctx, "array[2]/something", null);
     }
 
+    @Test
     public void testRootAsCollection() {
         assertXPathValue(context, ".[1]/string", "string");
     }
 
+    @Test
     public void testCreatePath() {
         context = JXPathContext.newContext(new TestBean());
         context.setFactory(new TestMixedModelFactory());
@@ -349,6 +387,7 @@ public class MixedModelTest extends AbstractJXPathTest {
     /**
      * Test JXPath.iterate() with map containing an array
      */
+    @Test
     public void testIterateArray() {
         final Map map = new HashMap();
         map.put("foo", new String[] { "a", "b", "c" });
@@ -358,6 +397,7 @@ public class MixedModelTest extends AbstractJXPathTest {
         assertXPathValueIterator(context, "foo", list("a", "b", "c"));
     }
 
+    @Test
     public void testIteratePointersArray() {
         final Map map = new HashMap();
         map.put("foo", new String[] { "a", "b", "c" });
@@ -371,11 +411,12 @@ public class MixedModelTest extends AbstractJXPathTest {
             actual.add(context.getValue(ptr.asPath()));
         }
         assertEquals(
-            "Iterating pointers <" + "foo" + ">",
             list("a", "b", "c"),
-            actual);
+            actual,
+            "Iterating pointers <" + "foo" + ">");
     }
 
+    @Test
     public void testIteratePointersArrayElementWithVariable() {
         final Map map = new HashMap();
         map.put("foo", new String[] { "a", "b", "c" });
@@ -388,9 +429,10 @@ public class MixedModelTest extends AbstractJXPathTest {
             final Pointer ptr = it.next();
             actual.add(context.getValue(ptr.asPath()));
         }
-        assertEquals("Iterating pointers <" + "foo" + ">", list("b"), actual);
+        assertEquals(list("b"), actual, "Iterating pointers <" + "foo" + ">");
     }
 
+    @Test
     public void testIterateVector() {
         final Map map = new HashMap();
         final Vector vec = new Vector();
@@ -405,6 +447,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             list("/.[@name='vec'][1]", "/.[@name='vec'][2]"));
     }
 
+    @Test
     public void testErrorProperty() {
         context.getVariables().declareVariable(
             "e",
@@ -417,7 +460,7 @@ public class MixedModelTest extends AbstractJXPathTest {
         catch (final Throwable t) {
             ex = true;
         }
-        assertTrue("Legitimate exception accessing property", ex);
+        assertTrue(ex, "Legitimate exception accessing property");
 
         assertXPathPointer(context, "$e/errorString", "$e/errorString");
 
@@ -437,6 +480,7 @@ public class MixedModelTest extends AbstractJXPathTest {
             Collections.EMPTY_LIST);
     }
 
+    @Test
     public void testMatrix() {
         assertXPathValueAndPointer(
             context,
@@ -473,7 +517,7 @@ public class MixedModelTest extends AbstractJXPathTest {
         catch (final Exception e) {
             ex = true;
         }
-        assertTrue("Exception setting value of non-existent element", ex);
+        assertTrue(ex, "Exception setting value of non-existent element");
 
         ex = false;
         try {
@@ -482,9 +526,10 @@ public class MixedModelTest extends AbstractJXPathTest {
         catch (final Exception e) {
             ex = true;
         }
-        assertTrue("Exception setting value of non-existent element", ex);
+        assertTrue(ex, "Exception setting value of non-existent element");
     }
 
+    @Test
     public void testCreatePathAndSetValueWithMatrix() {
 
         context.setValue("matrix", null);
@@ -501,6 +546,7 @@ public class MixedModelTest extends AbstractJXPathTest {
     /**
      * Scott Heaberlin's test - collection of collections
      */
+    @Test
     public void testCollectionPointer() {
         final List list = new ArrayList();
         final Map map = new HashMap();

--- a/src/test/java/org/apache/commons/jxpath/ri/model/XMLPreserveSpaceTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/XMLPreserveSpaceTest.java
@@ -19,6 +19,9 @@ package org.apache.commons.jxpath.ri.model;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for text trimming from JXPATH-83.
@@ -40,45 +43,55 @@ public class XMLPreserveSpaceTest extends AbstractJXPathTest {
     protected void doTest(final String id, final String model, final String expectedValue) {
         final JXPathContext context = JXPathContext
                 .newContext(createDocumentContainer(model));
-        assertEquals(context.getValue("test/text[@id='" + id + "']"), expectedValue);
+        assertEquals(expectedValue, context.getValue("test/text[@id='" + id + "']"));
     }
 
+    @Test
     public void testUnspecifiedDOM() {
         doTest("unspecified", DocumentContainer.MODEL_DOM, " foo ");
     }
 
+    @Test
     public void testDefaultDOM() {
         doTest("default", DocumentContainer.MODEL_DOM, "foo");
     }
 
+    @Test
     public void testPreserveDOM() {
         doTest("preserve", DocumentContainer.MODEL_DOM, " foo ");
     }
 
+    @Test
     public void testNestedDOM() {
         doTest("nested", DocumentContainer.MODEL_DOM, " foo ;bar; baz ");
     }
 
+    @Test
     public void testNestedWithCommentsDOM() {
         doTest("nested-with-comments", DocumentContainer.MODEL_DOM, " foo ;bar; baz ");
     }
 
+    @Test
     public void testUnspecifiedJDOM() {
         doTest("unspecified", DocumentContainer.MODEL_JDOM, " foo ");
     }
 
+    @Test
     public void testDefaultJDOM() {
         doTest("default", DocumentContainer.MODEL_JDOM, "foo");
     }
 
+    @Test
     public void testPreserveJDOM() {
         doTest("preserve", DocumentContainer.MODEL_JDOM, " foo ");
     }
 
+    @Test
     public void testNestedJDOM() {
         doTest("nested", DocumentContainer.MODEL_JDOM, " foo ;bar; baz ");
     }
 
+    @Test
     public void testNestedWithCommentsJDOM() {
         doTest("nested-with-comments", DocumentContainer.MODEL_JDOM, " foo ;bar; baz ");
     }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/XMLSpaceTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/XMLSpaceTest.java
@@ -19,6 +19,9 @@ package org.apache.commons.jxpath.ri.model;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for text trimming from JXPATH-83.
@@ -40,45 +43,55 @@ public class XMLSpaceTest extends AbstractJXPathTest {
     protected void doTest(final String id, final String model, final String expectedValue) {
         final JXPathContext context = JXPathContext
                 .newContext(createDocumentContainer(model));
-        assertEquals(context.getValue("test/text[@id='" + id + "']"), expectedValue);
+        assertEquals(expectedValue, context.getValue("test/text[@id='" + id + "']"));
     }
 
+    @Test
     public void testUnspecifiedDOM() {
         doTest("unspecified", DocumentContainer.MODEL_DOM, "foo");
     }
 
+    @Test
     public void testDefaultDOM() {
         doTest("default", DocumentContainer.MODEL_DOM, "foo");
     }
 
+    @Test
     public void testPreserveDOM() {
         doTest("preserve", DocumentContainer.MODEL_DOM, " foo ");
     }
 
+    @Test
     public void testNestedDOM() {
         doTest("nested", DocumentContainer.MODEL_DOM, "foo;bar; baz ");
     }
 
+    @Test
     public void testNestedWithCommentsDOM() {
         doTest("nested-with-comments", DocumentContainer.MODEL_DOM, "foo;bar; baz ");
     }
 
+    @Test
     public void testUnspecifiedJDOM() {
         doTest("unspecified", DocumentContainer.MODEL_JDOM, "foo");
     }
 
+    @Test
     public void testDefaultJDOM() {
         doTest("default", DocumentContainer.MODEL_JDOM, "foo");
     }
 
+    @Test
     public void testPreserveJDOM() {
         doTest("preserve", DocumentContainer.MODEL_JDOM, " foo ");
     }
 
+    @Test
     public void testNestedJDOM() {
         doTest("nested", DocumentContainer.MODEL_JDOM, "foo;bar; baz ");
     }
 
+    @Test
     public void testNestedWithCommentsJDOM() {
         doTest("nested-with-comments", DocumentContainer.MODEL_JDOM, "foo;bar; baz ");
     }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/XMLUpperCaseElementsTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/XMLUpperCaseElementsTest.java
@@ -19,6 +19,9 @@ package org.apache.commons.jxpath.ri.model;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for uppercase element matching, etc. showing JXPATH-136 is not reproducible.
@@ -37,24 +40,28 @@ public class XMLUpperCaseElementsTest extends AbstractJXPathTest {
 
     protected void doTest(final String id, final String model, final String expectedValue) {
         final JXPathContext context = JXPathContext.newContext(createDocumentContainer(model));
-        assertEquals(context.getValue("test/text[@id='" + id + "']"), expectedValue);
+        assertEquals(expectedValue, context.getValue("test/text[@id='" + id + "']"));
     }
 
+    @Test
     public void testBasicGetDOM() {
         assertXPathValue(createContext(DocumentContainer.MODEL_DOM), "/Vendor[1]/Contact[1]",
                 "John");
     }
 
+    @Test
     public void testBasicGetJDOM() {
         assertXPathValue(createContext(DocumentContainer.MODEL_JDOM), "/Vendor[1]/Contact[1]",
                 "John");
     }
 
+    @Test
     public void testBasicIterateDOM() {
         assertXPathValueIterator(createContext(DocumentContainer.MODEL_DOM), "/Vendor/Contact",
                 list("John", "Jack", "Jim", "Jack Black"));
     }
 
+    @Test
     public void testBasicIterateJDOM() {
         assertXPathValueIterator(createContext(DocumentContainer.MODEL_JDOM), "/Vendor/Contact",
                 list("John", "Jack", "Jim", "Jack Black"));

--- a/src/test/java/org/apache/commons/jxpath/ri/model/beans/BadlyImplementedFactoryTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/beans/BadlyImplementedFactoryTest.java
@@ -25,16 +25,20 @@ import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.JXPathException;
 import org.apache.commons.jxpath.Pointer;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Badly-implemented Factory test.  From JIRA JXPATH-68.
  */
-public class BadlyImplementedFactoryTest extends TestCase {
+public class BadlyImplementedFactoryTest {
 
     private JXPathContext context;
 
-    @Override
+    @BeforeEach
     public void setUp() {
         context = JXPathContext.newContext(new HashMap());
         context.setFactory(new AbstractFactory() {
@@ -46,12 +50,13 @@ public class BadlyImplementedFactoryTest extends TestCase {
         });
     }
 
+    @Test
     public void testBadFactoryImplementation() {
         try {
             context.createPath("foo/bar");
             fail("should fail with JXPathException caused by JXPathAbstractFactoryException");
         } catch (final JXPathException e) {
-            assertTrue(e.getCause() instanceof JXPathAbstractFactoryException);
+            assertInstanceOf(JXPathAbstractFactoryException.class, e.getCause());
         }
     }
 

--- a/src/test/java/org/apache/commons/jxpath/ri/model/beans/BeanModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/beans/BeanModelTest.java
@@ -20,6 +20,7 @@ import org.apache.commons.jxpath.AbstractFactory;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.TestBean;
 import org.apache.commons.jxpath.ri.model.AbstractBeanModelTest;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests JXPath with JavaBeans
@@ -37,6 +38,7 @@ public class BeanModelTest extends AbstractBeanModelTest {
         return new TestBeanFactory();
     }
 
+    @Test
     public void testIndexedProperty() {
         final JXPathContext context =
             JXPathContext.newContext(null, new TestIndexedPropertyBean());

--- a/src/test/java/org/apache/commons/jxpath/ri/model/container/ContainerModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/container/ContainerModelTest.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import org.apache.commons.jxpath.Container;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests JXPath with containers as root or value of a variable, property, etc.
@@ -77,6 +80,7 @@ public class ContainerModelTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testContainerVariableWithCollection() {
         final ArrayContainer container = new ArrayContainer();
         final String[] array = (String[]) container.getValue();
@@ -89,9 +93,10 @@ public class ContainerModelTest extends AbstractJXPathTest {
         assertXPathValueAndPointer(context, "$list[2]", "bar", "$list[2]");
 
         assertXPathSetValue(context, "$list[1]", "baz");
-        assertEquals("Checking setValue(index)", "baz", array[0]);
+        assertEquals("baz", array[0], "Checking setValue(index)");
     }
 
+    @Test
     public void testContainerPropertyWithCollection() {
         final Bean bean = new Bean();
         final List list = (List) bean.getContainer().getValue();
@@ -106,9 +111,10 @@ public class ContainerModelTest extends AbstractJXPathTest {
                 list.get(1), "/container[2]");
 
         assertXPathSetValue(context, "/container[1]", "baz");
-        assertEquals("Checking setValue(index)", "baz", list.get(0));
+        assertEquals("baz", list.get(0), "Checking setValue(index)");
     }
 
+    @Test
     public void testContainerMapWithCollection() {
         final ListContainer container = new ListContainer();
         final List list = (List) container.getValue();
@@ -126,9 +132,10 @@ public class ContainerModelTest extends AbstractJXPathTest {
                 list.get(1), "/.[@name='container'][2]");
 
         assertXPathSetValue(context, "/container[1]", "baz");
-        assertEquals("Checking setValue(index)", "baz", list.get(0));
+        assertEquals("baz", list.get(0), "Checking setValue(index)");
     }
 
+    @Test
     public void testContainerRootWithCollection() {
         final ArrayContainer container = new ArrayContainer();
         final String[] array = (String[]) container.getValue();
@@ -141,6 +148,6 @@ public class ContainerModelTest extends AbstractJXPathTest {
         assertXPathValueAndPointer(context, "/.[2]", "bar", "/.[2]");
 
         assertXPathSetValue(context, "/.[1]", "baz");
-        assertEquals("Checking setValue(index)", "baz", array[0]);    }
+        assertEquals("baz", array[0], "Checking setValue(index)");    }
 
 }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/dom/DOMModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/dom/DOMModelTest.java
@@ -20,11 +20,14 @@ import org.apache.commons.jxpath.AbstractFactory;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.ri.model.AbstractXMLModelTest;
 import org.apache.commons.jxpath.xml.DocumentContainer;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Tests JXPath with DOM
@@ -42,6 +45,7 @@ public class DOMModelTest extends AbstractXMLModelTest {
         return new TestDOMFactory();
     }
 
+    @Test
     public void testGetNode() {
         assertXPathNodeType(context, "/", Document.class);
         assertXPathNodeType(context, "/vendor/location", Element.class);
@@ -49,9 +53,10 @@ public class DOMModelTest extends AbstractXMLModelTest {
         assertXPathNodeType(context, "//vendor", Element.class);
     }
 
+    @Test
     public void testGetElementDescendantOrSelf() {
         final JXPathContext childContext = context.getRelativeContext(context.getPointer("/vendor"));
-        assertTrue(childContext.getContextBean() instanceof Element);
+        assertInstanceOf(Element.class, childContext.getContextBean());
         assertXPathNodeType(childContext, "//vendor", Element.class);
     }
 

--- a/src/test/java/org/apache/commons/jxpath/ri/model/dynabeans/LazyDynaBeanTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/dynabeans/LazyDynaBeanTest.java
@@ -21,17 +21,22 @@ import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.JXPathNotFoundException;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.ri.JXPathContextReferenceImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  */
 public class LazyDynaBeanTest extends AbstractJXPathTest {
 
+    @Test
     public void testLazyProperty() throws JXPathNotFoundException {
         final LazyDynaBean bean = new LazyDynaBean();
         final JXPathContext context = JXPathContext.newContext(bean);
         context.getValue("nosuch");
     }
 
+    @Test
     public void testStrictLazyDynaBeanPropertyFactory() {
         final StrictLazyDynaBeanPointerFactory factory = new StrictLazyDynaBeanPointerFactory();
         JXPathContextReferenceImpl.addNodePointerFactory(factory);

--- a/src/test/java/org/apache/commons/jxpath/ri/model/dynamic/DynamicPropertiesModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/dynamic/DynamicPropertiesModelTest.java
@@ -24,6 +24,11 @@ import java.util.Map;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.TestBean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * TODO more iterator testing with maps
@@ -33,6 +38,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
     private JXPathContext context;
 
     @Override
+    @BeforeEach
     public void setUp() {
         if (context == null) {
             context = JXPathContext.newContext(new TestBean());
@@ -40,6 +46,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
         }
     }
 
+    @Test
     public void testAxisChild() {
         assertXPathValue(context, "map/Key1", "Value 1");
 
@@ -50,6 +57,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
         assertXPathPointer(context, "map/Key2/name", "/map[@name='Key2']/name");
     }
 
+    @Test
     public void testAxisDescendant() {
         assertXPathValue(context, "//Key1", "Value 1");
     }
@@ -58,6 +66,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
      * Testing the pseudo-attribute "name" that dynamic property
      * objects appear to have.
      */
+    @Test
     public void testAttributeName() {
         assertXPathValue(context, "map[@name = 'Key1']", "Value 1");
 
@@ -112,10 +121,12 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='Key:4:5']");
     }
 
+    @Test
     public void testSetPrimitiveValue() {
         assertXPathSetValue(context, "map/Key1", Integer.valueOf(6));
     }
 
+    @Test
     public void testSetCollection() {
         // See if we can assign a whole collection
         context.setValue(
@@ -130,6 +141,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
      * The key does not exist, but the assignment should succeed anyway,
      * because you should always be able to store anything in a Map.
      */
+    @Test
     public void testSetNewKey() {
         // Using a "simple" path
         assertXPathSetValue(context, "map/Key4", Integer.valueOf(7));
@@ -140,6 +152,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
         assertXPathSetValue(context, "//map/Key5", Integer.valueOf(8));
     }
 
+    @Test
     public void testCreatePath() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -153,6 +166,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey1']");
     }
 
+    @Test
     public void testCreatePathAndSetValue() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -166,6 +180,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey1']");
     }
 
+    @Test
     public void testCreatePathCreateBean() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -180,6 +195,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey2']/int");
     }
 
+    @Test
     public void testCreatePathAndSetValueCreateBean() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -194,6 +210,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey2']/int");
     }
 
+    @Test
     public void testCreatePathCollectionElement() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -212,6 +229,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey3'][3]");
     }
 
+    @Test
     public void testCreatePathAndSetValueCollectionElement() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -230,6 +248,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey3'][3]");
     }
 
+    @Test
     public void testCreatePathNewCollectionElement() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -251,6 +270,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey4'][1]/int");
     }
 
+    @Test
     public void testCreatePathAndSetValueNewCollectionElement() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.setMap(null);
@@ -272,29 +292,31 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             "/map[@name='TestKey4'][1]/int");
     }
 
+    @Test
     public void testRemovePath() {
         final TestBean bean = (TestBean) context.getContextBean();
         bean.getMap().put("TestKey1", "test");
 
         // Remove dynamic property
         context.removePath("map[@name = 'TestKey1']");
-        assertEquals(
-            "Remove dynamic property value",
-            null,
-            context.getValue("map[@name = 'TestKey1']"));
+        assertNull(
+            context.getValue("map[@name = 'TestKey1']"),
+            "Remove dynamic property value");
     }
 
+    @Test
     public void testRemovePathArrayElement() {
         final TestBean bean = (TestBean) context.getContextBean();
 
         bean.getMap().put("TestKey2", new String[] { "temp1", "temp2" });
         context.removePath("map[@name = 'TestKey2'][1]");
         assertEquals(
-            "Remove dynamic property collection element",
             "temp2",
-            context.getValue("map[@name = 'TestKey2'][1]"));
+            context.getValue("map[@name = 'TestKey2'][1]"),
+            "Remove dynamic property collection element");
     }
 
+    @Test
     public void testCollectionOfMaps() {
         final TestBean bean = (TestBean) context.getContextBean();
         final List list = new ArrayList();
@@ -324,6 +346,7 @@ public class DynamicPropertiesModelTest extends AbstractJXPathTest {
             list("apple", "banana"));
     }
 
+    @Test
     public void testMapOfMaps() {
         final TestBean bean = (TestBean) context.getContextBean();
 

--- a/src/test/java/org/apache/commons/jxpath/ri/model/jdom/JDOMModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/jdom/JDOMModelTest.java
@@ -27,6 +27,10 @@ import org.jdom.CDATA;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Text;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Tests JXPath with JDOM
@@ -38,6 +42,7 @@ public class JDOMModelTest extends AbstractXMLModelTest {
         return DocumentContainer.MODEL_JDOM;
     }
 
+    @Test
     public void testGetNode() {
         assertXPathNodeType(context, "/", Document.class);
         assertXPathNodeType(context, "/vendor/location", Element.class);
@@ -45,13 +50,16 @@ public class JDOMModelTest extends AbstractXMLModelTest {
         assertXPathNodeType(context, "//vendor", Element.class); //bugzilla #38586
     }
 
+    @Test
     public void testGetElementDescendantOrSelf() {
         final JXPathContext childContext = context.getRelativeContext(context.getPointer("/vendor"));
-        assertTrue(childContext.getContextBean() instanceof Element);
+        assertInstanceOf(Element.class, childContext.getContextBean());
         assertXPathNodeType(childContext, "//vendor", Element.class);
     }
 
     @Override
+    @Test
+    @Disabled("id() is not supported by JDOM")
     public void testID() {
         // id() is not supported by JDOM
     }

--- a/src/test/java/org/apache/commons/jxpath/servlet/JXPathServletContextTest.java
+++ b/src/test/java/org/apache/commons/jxpath/servlet/JXPathServletContextTest.java
@@ -31,11 +31,18 @@ import com.mockrunner.mock.web.MockPageContext;
 import com.mockrunner.mock.web.MockServletConfig;
 import com.mockrunner.mock.web.MockServletContext;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  */
-public class JXPathServletContextTest extends TestCase {
+public class JXPathServletContextTest {
 
     private ServletContext getServletContext() {
         final MockServletContext context = new MockServletContext();
@@ -44,26 +51,28 @@ public class JXPathServletContextTest extends TestCase {
         return context;
     }
 
+    @Test
     public void testServletContext() {
         final ServletContext context = getServletContext();
         final JXPathContext appContext = JXPathServletContexts.getApplicationContext(context);
 
-        assertSame("Cached context not property returned", appContext, JXPathServletContexts.getApplicationContext(context));
+        assertSame(appContext, JXPathServletContexts.getApplicationContext(context), "Cached context not property returned");
 
-        assertEquals("Application Context", "OK", appContext.getValue("app"));
+        assertEquals("OK", appContext.getValue("app"), "Application Context");
 
         checkPointerIterator(appContext);
 
         // test setting a value in the context
         appContext.setValue("/foo", "bar");
-        assertEquals("Context property", "bar", appContext.getValue("/foo"));
+        assertEquals("bar", appContext.getValue("/foo"), "Context property");
 
         // test the variables
         final Variables variables = appContext.getVariables();
-        assertNotNull("$application variable", variables.getVariable("application"));
-        assertNull("$foo variable", variables.getVariable("$foo"));
+        assertNotNull(variables.getVariable("application"), "$application variable");
+        assertNull(variables.getVariable("$foo"), "$foo variable");
     }
 
+    @Test
     public void testServletRequest() {
         final ServletContext context = getServletContext();
 
@@ -80,38 +89,39 @@ public class JXPathServletContextTest extends TestCase {
         request.setupAddParameter("multiparam", new String[] { "value1", "value2" });
         request.setupAddParameter("emptyparam", new String[0]);
 
-        assertSame("Request session", session, request.getSession());
+        assertSame(session, request.getSession(), "Request session");
 
         final JXPathContext reqContext = JXPathServletContexts.getRequestContext(request, context);
 
-        assertSame("Cached context not property returned", reqContext, JXPathServletContexts.getRequestContext(request, context));
+        assertSame(reqContext, JXPathServletContexts.getRequestContext(request, context), "Cached context not property returned");
 
         final JXPathContext sessionContext = JXPathServletContexts.getSessionContext(session, context);
 
-        assertSame("Cached context not property returned", sessionContext, JXPathServletContexts.getSessionContext(session, context));
+        assertSame(sessionContext, JXPathServletContexts.getSessionContext(session, context), "Cached context not property returned");
 
-        assertEquals("Request Context Attribute", "OK", reqContext.getValue("attr"));
+        assertEquals("OK", reqContext.getValue("attr"), "Request Context Attribute");
 
-        assertEquals("Request Context Parameter", "OK", reqContext.getValue("parm"));
-        assertTrue("Request Context Parameter (Array)", reqContext.getValue("multiparam").getClass().isArray());
-        assertEquals("Request Context Parameter (Empty)", null, reqContext.getValue("emptyparam"));
+        assertEquals("OK", reqContext.getValue("parm"), "Request Context Parameter");
+        assertTrue(reqContext.getValue("multiparam").getClass().isArray(), "Request Context Parameter (Array)");
+        assertNull(reqContext.getValue("emptyparam"), "Request Context Parameter (Empty)");
 
-        assertEquals("Session Context Parameter", count, sessionContext.getValue("count"));
-        assertEquals("Application Context via Request Context", "OK", reqContext.getValue("app"));
-        assertEquals("Session Context via Request Context", count, reqContext.getValue("count"));
-        assertEquals("Application Context via Session Context", "OK", sessionContext.getValue("app"));
+        assertEquals(count, sessionContext.getValue("count"), "Session Context Parameter");
+        assertEquals("OK", reqContext.getValue("app"), "Application Context via Request Context");
+        assertEquals(count, reqContext.getValue("count"), "Session Context via Request Context");
+        assertEquals("OK", sessionContext.getValue("app"), "Application Context via Session Context");
 
         checkPointerIterator(reqContext);
         checkPointerIterator(sessionContext);
 
         // test setting a value in the context
         reqContext.setValue("/foo1", "bar1");
-        assertEquals("Context property", "bar1", reqContext.getValue("/foo1"));
+        assertEquals("bar1", reqContext.getValue("/foo1"), "Context property");
 
         sessionContext.setValue("/foo2", "bar2");
-        assertEquals("Context property", "bar2", sessionContext.getValue("/foo2"));
+        assertEquals("bar2", sessionContext.getValue("/foo2"), "Context property");
     }
 
+    @Test
     public void testServletRequestWithoutSession() {
         final ServletContext context = getServletContext();
 
@@ -119,20 +129,21 @@ public class JXPathServletContextTest extends TestCase {
 
         final JXPathContext reqContext = JXPathServletContexts.getRequestContext(request, context);
 
-        assertEquals("Application Context via Request Context", "OK", reqContext.getValue("app"));
+        assertEquals("OK", reqContext.getValue("app"), "Application Context via Request Context");
     }
 
     private void checkPointerIterator(final JXPathContext context) {
         final Iterator<Pointer> it = context.iteratePointers("/*");
-        assertTrue("Empty context", it.hasNext());
+        assertTrue(it.hasNext(), "Empty context");
         while (it.hasNext())
         {
             final Pointer pointer = it.next();
-            assertNotNull("null pointer", pointer);
-            assertNotNull("null path", pointer.asPath());
+            assertNotNull(pointer, "null pointer");
+            assertNotNull(pointer.asPath(), "null path");
         }
     }
 
+    @Test
     public void testPageContext() {
         final MockServletContext servletContext = new MockServletContext();
         servletContext.setAttribute("app", "app");
@@ -153,35 +164,35 @@ public class JXPathServletContextTest extends TestCase {
         pageContext.setServletRequest(request);
         pageContext.setAttribute("page", "page");
 
-        assertSame("Request session", session, request.getSession());
+        assertSame(session, request.getSession(), "Request session");
 
         final JXPathContext context = JXPathServletContexts.getPageContext(pageContext);
         context.setLenient(true);
 
         checkPointerIterator(context);
 
-        assertEquals("Page Scope", "page", context.getValue("page"));
-        assertEquals("Request Scope", "request", context.getValue("request"));
-        assertEquals("Session Scope", "session", context.getValue("session"));
-        assertEquals("Application Scope", "app", context.getValue("app"));
+        assertEquals("page", context.getValue("page"), "Page Scope");
+        assertEquals("request", context.getValue("request"), "Request Scope");
+        assertEquals("session", context.getValue("session"), "Session Scope");
+        assertEquals("app", context.getValue("app"), "Application Scope");
 
-        assertEquals("Explicit Page Scope", "page", context.getValue("$page/page"));
-        assertEquals("Explicit Request Scope", "request", context.getValue("$request/request"));
-        assertEquals("Explicit Session Scope", "session", context.getValue("$session/session"));
-        assertEquals("Explicit Application Scope", "app", context.getValue("$application/app"));
+        assertEquals("page", context.getValue("$page/page"), "Explicit Page Scope");
+        assertEquals("request", context.getValue("$request/request"), "Explicit Request Scope");
+        assertEquals("session", context.getValue("$session/session"), "Explicit Session Scope");
+        assertEquals("app", context.getValue("$application/app"), "Explicit Application Scope");
 
         // iterate through the elements of page context only (two elements expected, 'page' and the context)
         final Iterator<Pointer> it = context.iteratePointers("$page/*");
-        assertTrue("element not found", it.hasNext());
+        assertTrue(it.hasNext(), "element not found");
         it.next();
         it.next();
-        assertFalse("too many elements", it.hasNext());
+        assertFalse(it.hasNext(), "too many elements");
 
         // test setting a value in the context
         context.setValue("/foo1", "bar1");
-        assertEquals("Context property", "bar1", context.getValue("/foo1"));
+        assertEquals("bar1", context.getValue("/foo1"), "Context property");
 
         context.setValue("$page/foo2", "bar2");
-        assertEquals("Context property", "bar2", context.getValue("$page/foo2"));
+        assertEquals("bar2", context.getValue("$page/foo2"), "Context property");
     }
 }

--- a/src/test/java/org/apache/commons/jxpath/util/BasicTypeConverterTest.java
+++ b/src/test/java/org/apache/commons/jxpath/util/BasicTypeConverterTest.java
@@ -27,17 +27,22 @@ import java.util.List;
 import org.apache.commons.jxpath.NodeSet;
 import org.apache.commons.jxpath.Pointer;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests BasicTypeConverter
  */
-public class BasicTypeConverterTest extends TestCase {
+public class BasicTypeConverterTest {
 
+    @Test
     public void testPrimitiveToString() {
         assertConversion(Integer.valueOf(1), String.class, "1");
     }
 
+    @Test
     public void testArrayToList() {
         assertConversion(
             new int[] { 1, 2 },
@@ -45,6 +50,7 @@ public class BasicTypeConverterTest extends TestCase {
             Arrays.asList(new Object[] { Integer.valueOf(1), Integer.valueOf(2)}));
     }
 
+    @Test
     public void testArrayToArray() {
         assertConversion(
             new int[] { 1, 2 },
@@ -52,6 +58,7 @@ public class BasicTypeConverterTest extends TestCase {
             Arrays.asList(new String[] { "1", "2" }));
     }
 
+    @Test
     public void testListToArray() {
         assertConversion(
             Arrays.asList(new Integer[] { Integer.valueOf(1), Integer.valueOf(2)}),
@@ -64,6 +71,7 @@ public class BasicTypeConverterTest extends TestCase {
             Arrays.asList(new Integer[] { Integer.valueOf(1), Integer.valueOf(2)}));
     }
 
+    @Test
     public void testInvalidConversion() {
         boolean exception = false;
         try {
@@ -72,12 +80,12 @@ public class BasicTypeConverterTest extends TestCase {
         catch (final Throwable ex) {
             exception = true;
         }
-        assertTrue("Type conversion exception", exception);
+        assertTrue(exception, "Type conversion exception");
     }
 
     public void assertConversion(final Object from, final Class toType, final Object expected) {
         final boolean can = TypeUtils.canConvert(from, toType);
-        assertTrue("Can convert: " + from.getClass() + " to " + toType, can);
+        assertTrue(can, "Can convert: " + from.getClass() + " to " + toType);
         Object result = TypeUtils.convert(from, toType);
         if (result.getClass().isArray()) {
             final ArrayList list = new ArrayList();
@@ -87,19 +95,22 @@ public class BasicTypeConverterTest extends TestCase {
             result = list;
         }
         assertEquals(
-            "Convert: " + from.getClass() + " to " + toType,
             expected,
-            result);
+            result,
+            "Convert: " + from.getClass() + " to " + toType);
     }
 
+    @Test
     public void testSingletonCollectionToString() {
         assertConversion(Collections.singleton("Earth"), String.class, "Earth");
     }
 
+    @Test
     public void testSingletonArrayToString() {
         assertConversion(new String[] { "Earth" }, String.class, "Earth");
     }
 
+    @Test
     public void testPointerToString() {
         assertConversion(new Pointer() {
             private static final long serialVersionUID = 1L;
@@ -133,6 +144,7 @@ public class BasicTypeConverterTest extends TestCase {
         }, String.class, "value");
     }
 
+    @Test
     public void testNodeSetToString() {
         assertConversion(new NodeSet() {
             @Override
@@ -154,6 +166,7 @@ public class BasicTypeConverterTest extends TestCase {
     }
 
     // succeeds in current version
+    @Test
     public void testNodeSetToInteger() {
         assertConversion(new NodeSet() {
             @Override
@@ -171,6 +184,7 @@ public class BasicTypeConverterTest extends TestCase {
         }, Integer.class, Integer.valueOf(9));
     }
 
+    @Test
     public void testBeanUtilsConverter() {
         assertConversion("12", BigDecimal.class, new BigDecimal(12));
     }

--- a/src/test/java/org/apache/commons/jxpath/util/ClassLoaderUtilTest.java
+++ b/src/test/java/org/apache/commons/jxpath/util/ClassLoaderUtilTest.java
@@ -26,12 +26,18 @@ import java.net.URL;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.JXPathException;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests org.apache.commons.jxpath.util.ClassLoaderUtil.
  */
-public class ClassLoaderUtilTest extends TestCase {
+public class ClassLoaderUtilTest {
 
   // These must be string literals, and not populated by calling getName() on
   // the respective classes, since the tests below will load this class in a
@@ -44,16 +50,16 @@ public class ClassLoaderUtilTest extends TestCase {
   /**
    * Setup for the tests.
    */
-  @Override
-public void setUp() {
+  @BeforeEach
+  public void setUp() {
     this.orginalContextClassLoader = Thread.currentThread().getContextClassLoader();
   }
 
   /**
    * Cleanup for the tests.
    */
-  @Override
-public void tearDown() {
+  @AfterEach
+  public void tearDown() {
     Thread.currentThread().setContextClassLoader(this.orginalContextClassLoader);
   }
 
@@ -61,6 +67,7 @@ public void tearDown() {
    * Tests that JXPath cannot dynamically load a class, which is not visible to
    * its class loader, when the context class loader is null.
    */
+  @Test
   public void testClassLoadFailWithoutContextClassLoader() {
     Thread.currentThread().setContextClassLoader(null);
     final ClassLoader cl = new TestClassLoader(getClass().getClassLoader());
@@ -72,6 +79,7 @@ public void tearDown() {
    * its class loader, when the context class loader is set and can load the
    * class.
    */
+  @Test
   public void testClassLoadSuccessWithContextClassLoader() {
     Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
     final ClassLoader cl = new TestClassLoader(getClass().getClassLoader());
@@ -83,6 +91,7 @@ public void tearDown() {
    * requested class when the context class loader is set but unable to load
    * the class.
    */
+  @Test
   public void testCurrentClassLoaderFallback() {
     final ClassLoader cl = new TestClassLoader(getClass().getClassLoader());
     Thread.currentThread().setContextClassLoader(cl);
@@ -93,6 +102,7 @@ public void tearDown() {
    * Tests that JXPath can dynamically load a class, which is visible to
    * its class loader, when there is no context class loader set.
    */
+  @Test
   public void testClassLoadSuccessWithoutContextClassLoader() {
     Thread.currentThread().setContextClassLoader(null);
     callExampleMessageMethodAndAssertSuccess();
@@ -108,7 +118,7 @@ public void tearDown() {
       context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()");
       fail("We should not be able to load "+EXAMPLE_CLASS_NAME+".");
     } catch ( final Exception e ) {
-      assertTrue( e instanceof JXPathException );
+      assertInstanceOf(JXPathException.class, e);
     }
   }
 

--- a/src/test/java/org/apache/commons/jxpath/util/ValueUtilsTest.java
+++ b/src/test/java/org/apache/commons/jxpath/util/ValueUtilsTest.java
@@ -21,15 +21,19 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class ValueUtilsTest extends TestCase {
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+public class ValueUtilsTest {
 
+    @Test
     public void testGetValueFromArrayTooSmall() {
         assertNull(ValueUtils.getValue(new Object[0], 2));
     }
 
+    @Test
     public void testGetValueFromListTooSmall() {
         assertNull(ValueUtils.getValue(Collections.EMPTY_LIST, 2));
     }
@@ -38,20 +42,24 @@ public class ValueUtilsTest extends TestCase {
      * This test would break without the patch and an NoSuchElementException being
      * thrown instead.
      */
+    @Test
     public void testGetValueFromSetTooSmall() {
         assertNull(ValueUtils.getValue(Collections.EMPTY_SET, 2));
     }
 
+    @Test
     public void testGetValueFromArray() {
         final Object data = new Object();
         assertSame(data, ValueUtils.getValue(new Object[] {data}, 0));
     }
 
+    @Test
     public void testGetValueFromList() {
         final Object data = new Object();
         assertSame(data, ValueUtils.getValue(Arrays.asList(data), 0));
     }
 
+    @Test
     public void testGetValueFromSet() {
         final Object data = new Object();
         final Set dataSet = new HashSet();
@@ -59,17 +67,20 @@ public class ValueUtilsTest extends TestCase {
         assertSame(data, ValueUtils.getValue(dataSet, 0));
     }
 
+    @Test
     public void testGetValueFromArrayNegativeIndex() {
         final Object data = new Object();
         assertNull(ValueUtils.getValue(new Object[] {data}, -1));
     }
 
+    @Test
     public void testGetValueFromListNegativeIndex() {
         final Object data = new Object();
         final Object res = ValueUtils.getValue(Arrays.asList(data), -1);
-        assertNull("Expected null, is " + res, res);
+        assertNull(res, "Expected null, is " + res);
     }
 
+    @Test
     public void testGetValueFromSetNegativeIndex() {
         final Object data = new Object();
         final Set dataSet = new HashSet();


### PR DESCRIPTION
Migrates tests to JUnit5. Changes include

* Updated JUnit dependency
* Replaced usage of `junit.framework.*` for the JUnit5 equivalents
* Flipped order of parameters for _some_ assertions comparing the expected vs. actual values
* Simplified _some_  assertions, e.g. `assertEquals(null, object)` becomes `assertNull(object)`

There would be plenty of other possible improvements and best-practises that were not implemented in order to keep the changeset minimal. If desired I could add these as well in a separate PR.

Verified with `mvn clean verify` that build passes before and after my changes. 
Overall number of tests and coverage did not change. Note that `org.apache.commons.jxpath.ri.model.jdom.JDOMModelTest#testID` did not do anything so I chose to use `@Disabled` with a meaningful message.