### PR TITLE
Replace try-catch constructs in tests with assertThrows

### DIFF
--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath113Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath113Test.java
@@ -17,6 +17,7 @@
 package org.apache.commons.jxpath.issues;
 
 import java.io.StringReader;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,7 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JXPath113Test extends AbstractJXPathTest
 {
@@ -39,7 +41,9 @@ public class JXPath113Test extends AbstractJXPathTest
         final Document doc = JAXP.getDocument("<xml/>");
         final JXPathContext context = JXPathContext.newContext(doc);
 
-        assertDoesNotThrow(() -> context.selectNodes("//following-sibling::node()"));
+        List result = context.selectNodes("//following-sibling::node()");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     static class JAXP

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath113Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath113Test.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 public class JXPath113Test extends AbstractJXPathTest
 {
 
@@ -36,7 +38,8 @@ public class JXPath113Test extends AbstractJXPathTest
     {
         final Document doc = JAXP.getDocument("<xml/>");
         final JXPathContext context = JXPathContext.newContext(doc);
-        context.selectNodes("//following-sibling::node()");
+
+        assertDoesNotThrow(() -> context.selectNodes("//following-sibling::node()"));
     }
 
     static class JAXP
@@ -54,21 +57,12 @@ public class JXPath113Test extends AbstractJXPathTest
             return builder.parse(is);
         }
 
-        private static DocumentBuilder getDocumentBuilder()
-        {
-            try
-            {
-                final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-                factory.setValidating(false);
-                factory.setNamespaceAware(true);
-                factory.setExpandEntityReferences(false);
-                return factory.newDocumentBuilder();
-            }
-            catch (final ParserConfigurationException e)
-            {
-                throw new Error("JAXP config error:" + e.getMessage(), e);
-            }
-
+        private static DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setValidating(false);
+            factory.setNamespaceAware(true);
+            factory.setExpandEntityReferences(false);
+            return factory.newDocumentBuilder();
         }
     }
 

--- a/src/test/java/org/apache/commons/jxpath/issues/JXPath172Test.java
+++ b/src/test/java/org/apache/commons/jxpath/issues/JXPath172Test.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JXPath172Test extends AbstractJXPathTest
 {
@@ -90,36 +90,10 @@ public class JXPath172Test extends AbstractJXPathTest
     public void testIssue172_propertyDoesNotExist_NotLenient()
     {
         final JXPathContext context = getContext(null, false);
-        try
-        {
-            final Object bRet = context.selectSingleNode("unexisting");
-            fail("" + bRet);
-        }
-        catch (final JXPathNotFoundException e)
-        {
 
-        }
-
-        try
-        {
-            final Pointer pointer = context.getPointer("unexisting");
-            fail(" " + pointer);
-        }
-        catch (final JXPathNotFoundException e)
-        {
-
-        }
-
-        try
-        {
-            final Pointer pointer = context.getPointer("value.unexisting");
-            fail(" " + pointer);
-        }
-        catch (final JXPathNotFoundException e)
-        {
-
-        }
-
+        assertThrows(JXPathNotFoundException.class, () -> context.selectSingleNode("unexisting"));
+        assertThrows(JXPathNotFoundException.class, () -> context.getPointer("unexisting"));
+        assertThrows(JXPathNotFoundException.class, () -> context.getPointer("value.unexisting"));
     }
 
     /**

--- a/src/test/java/org/apache/commons/jxpath/ri/ExceptionHandlerTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/ExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -57,34 +58,30 @@ public class ExceptionHandlerTest extends AbstractJXPathTest {
 
     @Test
     public void testHandleFoo() throws Exception {
-        try {
-            context.getValue("foo");
-            fail("expected Throwable");
-        } catch (Throwable t) {
-            while (t != null) {
-                if ("foo unavailable".equals(t.getMessage())) {
-                    return;
-                }
-                t = t.getCause();
+        Throwable t = assertThrows(Throwable.class, () -> context.getValue("foo"),
+            "expected Throwable");
+
+        while (t != null) {
+            if ("foo unavailable".equals(t.getMessage())) {
+                return;
             }
-            fail("expected \"foo unavailable\" in throwable chain");
+            t = t.getCause();
         }
+        fail("expected \"foo unavailable\" in throwable chain");
     }
 
     @Test
     public void testHandleBarBaz() throws Exception {
-        try {
-            context.getValue("bar/baz");
-            fail("expected Throwable");
-        } catch (Throwable t) {
-            while (t != null) {
-                if ("baz unavailable".equals(t.getMessage())) {
-                    return;
-                }
-                t = t.getCause();
+        Throwable t = assertThrows(Throwable.class, () -> context.getValue("bar/baz"),
+            "expected Throwable");
+
+        while (t != null) {
+            if ("baz unavailable".equals(t.getMessage())) {
+                return;
             }
-            fail("expected \"baz unavailable\" in throwable chain");
+            t = t.getCause();
         }
+        fail("expected \"baz unavailable\" in throwable chain");
     }
 
     public Bar getBar() {

--- a/src/test/java/org/apache/commons/jxpath/ri/JXPathContextReferenceImplTestCase.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/JXPathContextReferenceImplTestCase.java
@@ -21,8 +21,6 @@ import org.apache.commons.jxpath.ri.model.container.ContainerPointerFactory;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 public class JXPathContextReferenceImplTestCase {
 
     /**
@@ -31,10 +29,12 @@ public class JXPathContextReferenceImplTestCase {
     @Test
     public void testInit() {
         final ContainerPointerFactory factory = new ContainerPointerFactory();
-        assertDoesNotThrow(() -> JXPathContextReferenceImpl.addNodePointerFactory(factory));
-
-        while (JXPathContextReferenceImpl.removeNodePointerFactory(factory)) {
-            // NOP
+        try {
+            JXPathContextReferenceImpl.addNodePointerFactory(factory);
+        } finally {
+            while (JXPathContextReferenceImpl.removeNodePointerFactory(factory)) {
+                // NOP
+            }
         }
     }
 }

--- a/src/test/java/org/apache/commons/jxpath/ri/JXPathContextReferenceImplTestCase.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/JXPathContextReferenceImplTestCase.java
@@ -21,6 +21,8 @@ import org.apache.commons.jxpath.ri.model.container.ContainerPointerFactory;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 public class JXPathContextReferenceImplTestCase {
 
     /**
@@ -29,12 +31,10 @@ public class JXPathContextReferenceImplTestCase {
     @Test
     public void testInit() {
         final ContainerPointerFactory factory = new ContainerPointerFactory();
-        try {
-            JXPathContextReferenceImpl.addNodePointerFactory(factory);
-        } finally {
-            while (JXPathContextReferenceImpl.removeNodePointerFactory(factory)) {
+        assertDoesNotThrow(() -> JXPathContextReferenceImpl.addNodePointerFactory(factory));
 
-            }
+        while (JXPathContextReferenceImpl.removeNodePointerFactory(factory)) {
+            // NOP
         }
     }
 }

--- a/src/test/java/org/apache/commons/jxpath/ri/StressTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/StressTest.java
@@ -20,8 +20,8 @@ import org.apache.commons.jxpath.JXPathContext;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test thread safety.
@@ -32,7 +32,6 @@ public class StressTest {
     private static final int THREAD_DURATION = 1000;
     private static JXPathContext context;
     private static int count;
-    private static Throwable exception;
 
     @Test
     public void testThreads() throws Throwable {
@@ -47,16 +46,7 @@ public class StressTest {
         }
 
         for (final Thread element : threadArray) {
-            try {
-                element.join();
-            }
-            catch (final InterruptedException e) {
-                fail("Interrupted");
-            }
-        }
-
-        if (exception != null) {
-            throw exception;
+            assertDoesNotThrow(() -> element.join(), "Interrupted");
         }
         assertEquals(THREAD_COUNT * THREAD_DURATION, count, "Test count");
     }
@@ -64,8 +54,8 @@ public class StressTest {
     private static final class StressRunnable implements Runnable {
         @Override
         public void run() {
-            for (int j = 0; j < THREAD_DURATION && exception == null; j++) {
-                try {
+            for (int j = 0; j < THREAD_DURATION; j++) {
+                assertDoesNotThrow(() -> {
                     final double random = 1 + Math.random();
                     final double sum =
                         ((Double) context.getValue("/ + " + random))
@@ -74,10 +64,7 @@ public class StressTest {
                     synchronized (context) {
                         count++;
                     }
-                }
-                catch (final Throwable t) {
-                    exception = t;
-                }
+                });
             }
         }
     }

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreFunctionTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreFunctionTest.java
@@ -63,14 +63,8 @@ public class CoreFunctionTest extends AbstractJXPathTest {
         assertXPathValue(context, "ends-with('xabc', 'ab')", Boolean.FALSE);
         assertXPathValue(context, "contains('xabc', 'ab')", Boolean.TRUE);
         assertXPathValue(context, "contains('xabc', 'ba')", Boolean.FALSE);
-        assertXPathValue(
-            context,
-            "substring-before('1999/04/01', '/')",
-            "1999");
-        assertXPathValue(
-            context,
-            "substring-after('1999/04/01', '/')",
-            "04/01");
+        assertXPathValue(context,"substring-before('1999/04/01', '/')","1999");
+        assertXPathValue(context,"substring-after('1999/04/01', '/')","04/01");
         assertXPathValue(context, "substring('12345', 2, 3)", "234");
         assertXPathValue(context, "substring('12345', 2)", "2345");
         assertXPathValue(context, "substring('12345', 1.5, 2.6)", "234");

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/VariableTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/VariableTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test basic functionality of JXPath - infoset types,
@@ -73,26 +73,10 @@ public class VariableTest extends AbstractJXPathTest {
 
     @Test
     public void testInvalidVariableName() {
-        boolean exception = false;
-        try {
-            context.getValue("$none");
-        }
-        catch (final Exception ex) {
-            exception = true;
-        }
-        assertTrue(
-            exception,
+        assertThrows(Exception.class, () -> context.getValue("$none"),
             "Evaluating '$none', expected exception - did not get it");
 
-        exception = false;
-        try {
-            context.setValue("$none", Integer.valueOf(1));
-        }
-        catch (final Exception ex) {
-            exception = true;
-        }
-        assertTrue(
-            exception,
+        assertThrows(Exception.class, () -> context.setValue("$none", Integer.valueOf(1)),
             "Setting '$none = 1', expected exception - did not get it");
     }
 

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AbstractBeanModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AbstractBeanModelTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract superclass for Bean access with JXPath.
@@ -827,19 +827,13 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
             Integer.valueOf(1),
             "/nestedBean/int");
 
-        boolean ex = false;
-        try {
+        assertThrows(Exception.class, () ->
             assertXPathCreatePath(
                 context,
                 "/nestedBean/beans[last() + 1]",
                 Integer.valueOf(1),
-                "/nestedBean/beans[last() + 1]");
-        }
-        catch (final Exception e) {
-            ex = true;
-        }
-        assertTrue(ex, "Exception thrown on invalid path for creation");
-
+                "/nestedBean/beans[last() + 1]"),
+            "Exception thrown on invalid path for creation");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AbstractXMLModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AbstractXMLModelTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract superclass for pure XPath 1.0.  Subclasses
@@ -340,25 +340,15 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
 
         assertXPathValue(context, "/vendor/contact[@name='jim']", "Jim");
 
-        boolean nsv = false;
-        try {
+        assertThrows(JXPathException.class, () -> {
             context.setLenient(false);
             context.getValue("/vendor/contact[@name='jane']");
-        }
-        catch (final JXPathException ex) {
-            nsv = true;
-        }
-        assertTrue(nsv, "No such value: /vendor/contact[@name='jim']");
+        }, "No such value: /vendor/contact[@name='jim']");
 
-        nsv = false;
-        try {
+        assertThrows(JXPathException.class, () -> {
             context.setLenient(false);
             context.getValue("/vendor/contact[@name='jane']/*");
-        }
-        catch (final JXPathException ex) {
-            nsv = true;
-        }
-        assertTrue(nsv, "No such value: /vendor/contact[@name='jane']/*");
+        }, "No such value: /vendor/contact[@name='jane']/*");
 
         // child:: with a wildcard
         assertXPathValue(

--- a/src/test/java/org/apache/commons/jxpath/ri/model/MixedModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/MixedModelTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests JXPath with mixed model: beans, maps, DOM etc.
@@ -453,14 +453,8 @@ public class MixedModelTest extends AbstractJXPathTest {
             "e",
             new ExceptionPropertyTestBean());
 
-        boolean ex = false;
-        try {
-            assertXPathValue(context, "$e/errorString", null);
-        }
-        catch (final Throwable t) {
-            ex = true;
-        }
-        assertTrue(ex, "Legitimate exception accessing property");
+        assertThrows(Throwable.class, () -> assertXPathValue(context, "$e/errorString", null),
+            "Legitimate exception accessing property");
 
         assertXPathPointer(context, "$e/errorString", "$e/errorString");
 
@@ -510,23 +504,11 @@ public class MixedModelTest extends AbstractJXPathTest {
             Integer.valueOf(2),
             "$wholebean/matrix[1]/.[1]");
 
-        boolean ex = false;
-        try {
-            context.setValue("$wholebean/matrix[1]/.[2]", "4");
-        }
-        catch (final Exception e) {
-            ex = true;
-        }
-        assertTrue(ex, "Exception setting value of non-existent element");
+        assertThrows(Exception.class, () -> context.setValue("$wholebean/matrix[1]/.[2]", "4"),
+            "Exception setting value of non-existent element");
 
-        ex = false;
-        try {
-            context.setValue("$wholebean/matrix[2]/.[1]", "4");
-        }
-        catch (final Exception e) {
-            ex = true;
-        }
-        assertTrue(ex, "Exception setting value of non-existent element");
+        assertThrows(Exception.class, () -> context.setValue("$wholebean/matrix[2]/.[1]", "4"),
+           "Exception setting value of non-existent element");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/jxpath/ri/model/beans/BadlyImplementedFactoryTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/beans/BadlyImplementedFactoryTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Badly-implemented Factory test.  From JIRA JXPATH-68.
@@ -52,12 +52,9 @@ public class BadlyImplementedFactoryTest {
 
     @Test
     public void testBadFactoryImplementation() {
-        try {
-            context.createPath("foo/bar");
-            fail("should fail with JXPathException caused by JXPathAbstractFactoryException");
-        } catch (final JXPathException e) {
-            assertInstanceOf(JXPathAbstractFactoryException.class, e.getCause());
-        }
+        JXPathException e = assertThrows(JXPathException.class, () -> context.createPath("foo/bar"),
+            "should fail with JXPathException caused by JXPathAbstractFactoryException");
+        assertInstanceOf(JXPathAbstractFactoryException.class, e.getCause());
     }
 
 }

--- a/src/test/java/org/apache/commons/jxpath/ri/model/dynabeans/LazyDynaBeanTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/dynabeans/LazyDynaBeanTest.java
@@ -23,7 +23,7 @@ import org.apache.commons.jxpath.AbstractJXPathTest;
 import org.apache.commons.jxpath.ri.JXPathContextReferenceImpl;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  */
@@ -40,15 +40,10 @@ public class LazyDynaBeanTest extends AbstractJXPathTest {
     public void testStrictLazyDynaBeanPropertyFactory() {
         final StrictLazyDynaBeanPointerFactory factory = new StrictLazyDynaBeanPointerFactory();
         JXPathContextReferenceImpl.addNodePointerFactory(factory);
-        try {
-            testLazyProperty();
-            fail();
-        } catch (final JXPathNotFoundException e) {
-            // okay
-        } finally {
-            while (JXPathContextReferenceImpl.removeNodePointerFactory(factory)) {
+        assertThrows(JXPathNotFoundException.class, this::testLazyProperty);
 
-            }
+        while (JXPathContextReferenceImpl.removeNodePointerFactory(factory)) {
+            // NOP
         }
     }
 }

--- a/src/test/java/org/apache/commons/jxpath/util/BasicTypeConverterTest.java
+++ b/src/test/java/org/apache/commons/jxpath/util/BasicTypeConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.jxpath.Pointer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -73,14 +74,8 @@ public class BasicTypeConverterTest {
 
     @Test
     public void testInvalidConversion() {
-        boolean exception = false;
-        try {
-            TypeUtils.convert("'foo'", Date.class);
-        }
-        catch (final Throwable ex) {
-            exception = true;
-        }
-        assertTrue(exception, "Type conversion exception");
+        assertThrows(Exception.class, () -> TypeUtils.convert("'foo'", Date.class),
+            "Type conversion exception");
     }
 
     public void assertConversion(final Object from, final Class toType, final Object expected) {

--- a/src/test/java/org/apache/commons/jxpath/util/ClassLoaderUtilTest.java
+++ b/src/test/java/org/apache/commons/jxpath/util/ClassLoaderUtilTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -125,8 +124,13 @@ public class ClassLoaderUtilTest {
    */
   public static void callExampleMessageMethodAndAssertSuccess() {
     final JXPathContext context = JXPathContext.newContext(new Object());
-    Object value = assertDoesNotThrow(() -> context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()"));
-    assertEquals("an example class", value);
+    Object value;
+    try {
+      value = context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()");
+      assertEquals("an example class", value);
+    } catch ( final Exception e ) {
+      fail(e.getMessage());
+    }
   }
 
   /**
@@ -138,8 +142,18 @@ public class ClassLoaderUtilTest {
    * to invoke.
    */
   private void executeTestMethodUnderClassLoader(final ClassLoader cl, final String methodName) {
-    Class testClass = assertDoesNotThrow(() -> cl.loadClass(TEST_CASE_CLASS_NAME));
-    Method testMethod = assertDoesNotThrow(() -> testClass.getMethod(methodName, null));
+    Class testClass = null;
+    try {
+      testClass = cl.loadClass(TEST_CASE_CLASS_NAME);
+    } catch (final ClassNotFoundException e) {
+      fail(e.getMessage());
+    }
+    Method testMethod = null;
+    try {
+      testMethod = testClass.getMethod(methodName, null);
+    } catch (final SecurityException | NoSuchMethodException e) {
+      fail(e.getMessage());
+    }
 
     try {
       testMethod.invoke(null, null);

--- a/src/test/java/org/apache/commons/jxpath/util/ClassLoaderUtilTest.java
+++ b/src/test/java/org/apache/commons/jxpath/util/ClassLoaderUtilTest.java
@@ -30,8 +30,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -114,12 +115,8 @@ public class ClassLoaderUtilTest {
    */
   public static void callExampleMessageMethodAndAssertClassNotFoundJXPathException() {
     final JXPathContext context = JXPathContext.newContext(new Object());
-    try {
-      context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()");
-      fail("We should not be able to load "+EXAMPLE_CLASS_NAME+".");
-    } catch ( final Exception e ) {
-      assertInstanceOf(JXPathException.class, e);
-    }
+    assertThrows(JXPathException.class, () -> context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()"),
+      "We should not be able to load "+EXAMPLE_CLASS_NAME+".");
   }
 
   /**
@@ -128,13 +125,8 @@ public class ClassLoaderUtilTest {
    */
   public static void callExampleMessageMethodAndAssertSuccess() {
     final JXPathContext context = JXPathContext.newContext(new Object());
-    Object value;
-    try {
-      value = context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()");
-      assertEquals("an example class", value);
-    } catch ( final Exception e ) {
-      fail(e.getMessage());
-    }
+    Object value = assertDoesNotThrow(() -> context.selectSingleNode(EXAMPLE_CLASS_NAME+".getMessage()"));
+    assertEquals("an example class", value);
   }
 
   /**
@@ -146,18 +138,8 @@ public class ClassLoaderUtilTest {
    * to invoke.
    */
   private void executeTestMethodUnderClassLoader(final ClassLoader cl, final String methodName) {
-    Class testClass = null;
-    try {
-      testClass = cl.loadClass(TEST_CASE_CLASS_NAME);
-    } catch (final ClassNotFoundException e) {
-      fail(e.getMessage());
-    }
-    Method testMethod = null;
-    try {
-      testMethod = testClass.getMethod(methodName, null);
-    } catch (final SecurityException | NoSuchMethodException e) {
-      fail(e.getMessage());
-    }
+    Class testClass = assertDoesNotThrow(() -> cl.loadClass(TEST_CASE_CLASS_NAME));
+    Method testMethod = assertDoesNotThrow(() -> testClass.getMethod(methodName, null));
 
     try {
       testMethod.invoke(null, null);


### PR DESCRIPTION
As requested in https://github.com/apache/commons-jxpath/pull/214#issuecomment-2576085669

* Simplified tests by replacing `try-catch` constructs with `assertThrows` and `assertDoesNotThrow`

Verified with `mvn clean verify` that build passes before and after my changes. 
Overall number of tests and coverage did not change.