### PR TITLE
disable external entity resolution in XML parsers

### DIFF
--- a/src/main/java/org/apache/commons/jxpath/XMLDocumentContainer.java
+++ b/src/main/java/org/apache/commons/jxpath/XMLDocumentContainer.java
@@ -20,6 +20,7 @@ package org.apache.commons.jxpath;
 import java.net.URL;
 import java.util.Objects;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -85,7 +86,11 @@ public class XMLDocumentContainer implements Container {
             try {
                 if (source != null) {
                     final DOMResult result = new DOMResult();
-                    final Transformer trans = TransformerFactory.newInstance().newTransformer();
+                    final TransformerFactory factory = TransformerFactory.newInstance();
+                    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+                    final Transformer trans = factory.newTransformer();
                     trans.transform(source, result);
                     document = result.getNode();
                 } else {

--- a/src/main/java/org/apache/commons/jxpath/xml/DOMParser.java
+++ b/src/main/java/org/apache/commons/jxpath/xml/DOMParser.java
@@ -39,6 +39,10 @@ public class DOMParser extends XMLParser2 {
     public Object parseXML(final InputStream stream) {
         try {
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
             factory.setValidating(isValidating());
             factory.setNamespaceAware(isNamespaceAware());
             factory.setIgnoringElementContentWhitespace(isIgnoringElementContentWhitespace());

--- a/src/main/java/org/apache/commons/jxpath/xml/JDOMParser.java
+++ b/src/main/java/org/apache/commons/jxpath/xml/JDOMParser.java
@@ -18,9 +18,11 @@
 package org.apache.commons.jxpath.xml;
 
 import java.io.InputStream;
+import java.io.StringReader;
 
 import org.apache.commons.jxpath.JXPathException;
 import org.jdom.input.SAXBuilder;
+import org.xml.sax.InputSource;
 
 /**
  * An implementation of the XMLParser interface that produces a JDOM Document.
@@ -41,6 +43,11 @@ public class JDOMParser extends XMLParser2 {
         }
         try {
             final SAXBuilder builder = new SAXBuilder();
+            builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            // SAXBuilder.setExpandEntities(true) re-enables external general entity
+            // resolution, so refuse external lookups with a no-op resolver instead.
+            builder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
             builder.setExpandEntities(isExpandEntityReferences());
             builder.setIgnoringElementContentWhitespace(isIgnoringElementContentWhitespace());
             builder.setValidation(isValidating());

--- a/src/test/java/org/apache/commons/jxpath/xml/XXETest.java
+++ b/src/test/java/org/apache/commons/jxpath/xml/XXETest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.jxpath.xml;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.w3c.dom.Document;
+
+/**
+ * Tests that the XML parsers do not resolve external entities (XXE).
+ */
+class XXETest {
+
+    @TempDir
+    Path dir;
+
+    private URL buildDocument() {
+        try {
+            final Path secret = dir.resolve("secret.txt");
+            Files.write(secret, "TOP-SECRET".getBytes(StandardCharsets.UTF_8));
+            final Path xml = dir.resolve("xxe.xml");
+            Files.write(xml, ("<?xml version=\"1.0\"?>\n"
+                    + "<!DOCTYPE root [ <!ENTITY xxe SYSTEM \"" + secret.toUri() + "\"> ]>\n"
+                    + "<root>&xxe;</root>").getBytes(StandardCharsets.UTF_8));
+            return xml.toUri().toURL();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private String rootText(final String model, final Object document) {
+        if (DocumentContainer.MODEL_JDOM.equals(model)) {
+            return ((org.jdom.Document) document).getRootElement().getText();
+        }
+        return ((Document) document).getDocumentElement().getTextContent();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {DocumentContainer.MODEL_DOM, DocumentContainer.MODEL_JDOM})
+    void externalEntityIsNotResolved(final String model) {
+        final DocumentContainer container = new DocumentContainer(buildDocument(), model);
+        assertFalse(rootText(model, container.getValue()).contains("TOP-SECRET"));
+    }
+}


### PR DESCRIPTION
DOMParser, JDOMParser and the deprecated XMLDocumentContainer transform path parse XML from a caller-supplied URL/Source without turning off external entities, so a document carrying an external general entity like <!ENTITY xxe SYSTEM "file:///etc/passwd"> gets resolved at parse time and its contents land in the tree, which is the usual file-read / SSRF XXE. The fix turns off external general/parameter entities and external DTD loading inside each parser while leaving the internal DTD subset working, so the existing Vendor.xml style documents still parse. One thing I went back and forth on: for JDOM the SAX feature flags alone are not enough because setExpandEntities(true) re-enables external general entities afterward, so I refuse external lookups with a no-op EntityResolver there instead.