### PR TITLE
Use ConcurrentHashMap for DocumentContainer parser registries

### DIFF
--- a/src/main/java/org/apache/commons/jxpath/xml/DocumentContainer.java
+++ b/src/main/java/org/apache/commons/jxpath/xml/DocumentContainer.java
@@ -20,7 +20,8 @@ package org.apache.commons.jxpath.xml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.jxpath.Container;
 import org.apache.commons.jxpath.JXPathException;
@@ -39,14 +40,14 @@ public class DocumentContainer extends XMLParser2 implements Container {
     /** JDOM constant */
     public static final String MODEL_JDOM = "JDOM";
     private static final long serialVersionUID = -8713290334113427066L;
-    private static HashMap<String, String> parserClasses = new HashMap<>();
+    private static final Map<String, String> parserClasses = new ConcurrentHashMap<>();
 
     static {
         parserClasses.put(MODEL_DOM, "org.apache.commons.jxpath.xml.DOMParser");
         parserClasses.put(MODEL_JDOM, "org.apache.commons.jxpath.xml.JDOMParser");
     }
 
-    private static HashMap<String, XMLParser> parsers = new HashMap<>();
+    private static final Map<String, XMLParser> parsers = new ConcurrentHashMap<>();
 
     /**
      * Maps a model type to a parser.

--- a/src/test/java/org/apache/commons/jxpath/xml/DocumentContainerConcurrencyTest.java
+++ b/src/test/java/org/apache/commons/jxpath/xml/DocumentContainerConcurrencyTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.jxpath.xml;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the static parser registries in {@link DocumentContainer} tolerate concurrent access.
+ */
+class DocumentContainerConcurrencyTest {
+
+    private static final int THREAD_COUNT = 12;
+    private static final int ITERATIONS = 400;
+
+    @Test
+    void testConcurrentRegisterAndGetValue() throws InterruptedException {
+        final URL url = DocumentContainer.class.getResource("/org/apache/commons/jxpath/Vendor.xml");
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final Thread[] threads = new Thread[THREAD_COUNT];
+        for (int t = 0; t < THREAD_COUNT; t++) {
+            final int tid = t;
+            threads[t] = new Thread(() -> {
+                for (int i = 0; i < ITERATIONS && failure.get() == null; i++) {
+                    final String model = "model-" + tid + "-" + i;
+                    try {
+                        if ((tid & 1) == 0) {
+                            DocumentContainer.registerXMLParser(model, "org.apache.commons.jxpath.xml.DOMParser");
+                            new DocumentContainer(url, model).getValue();
+                        } else {
+                            DocumentContainer.registerXMLParser(model, new DOMParser());
+                        }
+                    } catch (final Throwable th) {
+                        failure.compareAndSet(null, th);
+                    }
+                }
+            });
+        }
+        for (final Thread thread : threads) {
+            thread.start();
+        }
+        for (final Thread thread : threads) {
+            thread.join();
+        }
+        assertNull(failure.get());
+    }
+}


### PR DESCRIPTION
Thanks for your contribution to [Apache Commons](https://commons.apache.org/)!

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.

`DocumentContainer` keeps two static registries, `parsers` and `parserClasses`, as plain `HashMap`. `registerXMLParser` mutates them with `put`, and `getParser` (reached through `getValue` then `parseXML`) mutates `parsers` with `computeIfAbsent`, none of it synchronized, while the rest of the library already uses `ConcurrentHashMap` for the same kind of registry (`JXPathIntrospector`, `ValueUtils`). When two threads first parse a given model concurrently, or one thread registers a parser while another parses, they race on the shared map. I hit a `ConcurrentModificationException` thrown from `HashMap.computeIfAbsent` in `getParser`, and on other runs a corrupted map spinning forever in `resize`/`treeify` inside `registerXMLParser` at 100% CPU. Switching both fields to `ConcurrentHashMap` lines them up with the other registries and drops the race. The added test reproduces it: it fails on the current code with the `ConcurrentModificationException` and passes with the change.
