### PR TITLE
Restrict XPath string-to-number conversion to the number grammar

### DIFF
--- a/src/main/java/org/apache/commons/jxpath/ri/InfoSetUtil.java
+++ b/src/main/java/org/apache/commons/jxpath/ri/InfoSetUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.jxpath.ri;
 
+import java.util.regex.Pattern;
+
 import org.apache.commons.jxpath.Pointer;
 import org.apache.commons.jxpath.ri.model.NodePointer;
 import org.apache.commons.jxpath.ri.model.VariablePointer;
@@ -29,6 +31,27 @@ public class InfoSetUtil {
     private static final Double ZERO = Double.valueOf(0);
     private static final Double ONE = Double.valueOf(1);
     private static final Double NOT_A_NUMBER = Double.valueOf(Double.NaN);
+
+    /**
+     * The lexical space a string may occupy to be converted to a number per the XPath 1.0 Number production: optional surrounding whitespace and an optional
+     * leading minus around {@code Digits ('.' Digits?)? | '.' Digits}. {@link Double#parseDouble(String)} additionally accepts Java-only forms (a leading
+     * {@code +}, exponents, {@code d}/{@code f} type suffixes, hexadecimal floats and the {@code Infinity}/{@code NaN} words), none of which are XPath numbers
+     * and all of which must convert to NaN.
+     */
+    private static final Pattern XPATH_NUMBER = Pattern.compile("[ \t\r\n]*-?(?:[0-9]+(?:\\.[0-9]*)?|\\.[0-9]+)[ \t\r\n]*");
+
+    /**
+     * Converts a string to a double using XPath rules, returning NaN for any string outside the XPath number lexical space.
+     *
+     * @param string value to convert
+     * @return double value or NaN
+     */
+    private static double parseNumber(final String string) {
+        if (XPATH_NUMBER.matcher(string).matches()) {
+            return Double.parseDouble(string.trim());
+        }
+        return Double.NaN;
+    }
 
     /**
      * Converts the supplied object to boolean.
@@ -81,11 +104,7 @@ public class InfoSetUtil {
             if (object.equals("")) {
                 return 0.0;
             }
-            try {
-                return Double.parseDouble((String) object);
-            } catch (final NumberFormatException ex) {
-                return Double.NaN;
-            }
+            return parseNumber((String) object);
         }
         if (object instanceof NodePointer) {
             return doubleValue(((NodePointer) object).getValue());
@@ -112,11 +131,8 @@ public class InfoSetUtil {
             return ((Boolean) object).booleanValue() ? ONE : ZERO;
         }
         if (object instanceof String) {
-            try {
-                return Double.valueOf((String) object);
-            } catch (final NumberFormatException ex) {
-                return NOT_A_NUMBER;
-            }
+            final double value = parseNumber((String) object);
+            return Double.isNaN(value) ? NOT_A_NUMBER : Double.valueOf(value);
         }
         if (object instanceof EvalContext) {
             final EvalContext ctx = (EvalContext) object;

--- a/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreFunctionTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/compiler/CoreFunctionTest.java
@@ -115,6 +115,24 @@ class CoreFunctionTest extends AbstractJXPathTest {
     }
 
     @Test
+    void testNumberConversionIsXPathConformant() {
+        // Java number literals that are outside the XPath 1.0 number grammar must convert to NaN.
+        assertXPathValue(context, "number('1e3')", Double.valueOf(Double.NaN));
+        assertXPathValue(context, "number('5d')", Double.valueOf(Double.NaN));
+        assertXPathValue(context, "number('5f')", Double.valueOf(Double.NaN));
+        assertXPathValue(context, "number('+5')", Double.valueOf(Double.NaN));
+        assertXPathValue(context, "number('Infinity')", Double.valueOf(Double.NaN));
+        // Valid XPath numbers still convert.
+        assertXPathValue(context, "number('1')", Double.valueOf(1));
+        assertXPathValue(context, "number('1.5')", Double.valueOf(1.5));
+        assertXPathValue(context, "number('-.5')", Double.valueOf(-0.5));
+        assertXPathValue(context, "number(' 42 ')", Double.valueOf(42));
+        // doubleValue() agrees: a non-XPath number is NaN, so numeric comparisons are false.
+        assertXPathValue(context, "'5d' >= 5", Boolean.FALSE);
+        assertXPathValue(context, "'1e3' = 1000", Boolean.FALSE);
+    }
+
+    @Test
     void testExtendedKeyFunction() {
         context.setKeyManager(new ExtendedKeyManager() {
 


### PR DESCRIPTION
- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

`InfoSetUtil.doubleValue` and `InfoSetUtil.number` coerce string values to numbers with `Double.parseDouble`/`Double.valueOf`, which accept Java number literals the XPath 1.0 number grammar does not: a leading `+`, exponents like `1e3`, `d`/`f` type suffixes like `5d`, hexadecimal floats, and the `Infinity`/`NaN` words. XPath requires every such string to become `NaN`, so today `number('1e3')` is `1000`, `'5d' >= 5` is true, and `'1e3' = 1000` is true. Spotted while checking `number()` against the spec; the existing `floor('NaN')` cases only pass because `Double.parseDouble` happens to accept `NaN`.

Both methods now gate the conversion on a `Pattern` for the `Number` production (optional whitespace and minus around digits with an optional fraction) and return `NaN` otherwise. The check lives in `InfoSetUtil` because `number()`, the relational operators and `floor`/`ceiling`/`round` all coerce through these two methods, so node models and callers stay untouched. `floor('NaN')` and friends keep returning `NaN` since the word is rejected the same way.
