### PR TITLE
Fix lang() to match whole language subtags, not any prefix

### DIFF
--- a/src/main/java/org/apache/commons/jxpath/ri/model/NodePointer.java
+++ b/src/main/java/org/apache/commons/jxpath/ri/model/NodePointer.java
@@ -750,12 +750,27 @@ public abstract class NodePointer implements Pointer {
      * Check whether our locale matches the specified language.
      *
      * @param lang String language to check
-     * @return true if the selected locale name starts with the specified prefix <em>lang</em>, case-insensitive.
+     * @return true if the selected locale name matches <em>lang</em> under the XPath {@code lang()} rules, case-insensitive.
      */
     public boolean isLanguage(final String lang) {
         final Locale loc = getLocale();
         final String name = loc.toString().replace('_', '-');
-        return name.toUpperCase(Locale.ENGLISH).startsWith(lang.toUpperCase(Locale.ENGLISH));
+        return isLanguage(name, lang);
+    }
+
+    /**
+     * Tests whether the language tag {@code value} matches {@code lang} under the XPath 1.0 {@code lang()} rules: the comparison is case-insensitive and
+     * {@code lang} must equal the whole tag or a leading subtag delimited by {@code '-'}. So {@code "en"} matches {@code "en"} and {@code "en-US"} but not
+     * {@code "english"}, and the bare prefix {@code "e"} matches neither.
+     *
+     * @param value the language tag to test, for example an {@code xml:lang} value or a locale name
+     * @param lang  the language being tested for
+     * @return whether {@code value} is {@code lang} or a sublanguage of it
+     */
+    protected static boolean isLanguage(final String value, final String lang) {
+        final String name = value.toUpperCase(Locale.ENGLISH);
+        final String target = lang.toUpperCase(Locale.ENGLISH);
+        return name.equals(target) || name.startsWith(target + "-");
     }
 
     /**

--- a/src/main/java/org/apache/commons/jxpath/ri/model/dom/DOMNodePointer.java
+++ b/src/main/java/org/apache/commons/jxpath/ri/model/dom/DOMNodePointer.java
@@ -679,7 +679,7 @@ public class DOMNodePointer extends NodePointer {
     @Override
     public boolean isLanguage(final String lang) {
         final String current = getLanguage();
-        return current == null ? super.isLanguage(lang) : current.toUpperCase(Locale.ENGLISH).startsWith(lang.toUpperCase(Locale.ENGLISH));
+        return current == null ? super.isLanguage(lang) : isLanguage(current, lang);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/jxpath/ri/model/jdom/JDOMNodePointer.java
+++ b/src/main/java/org/apache/commons/jxpath/ri/model/jdom/JDOMNodePointer.java
@@ -696,7 +696,7 @@ public class JDOMNodePointer extends NodePointer {
     @Override
     public boolean isLanguage(final String lang) {
         final String current = getLanguage();
-        return current == null ? super.isLanguage(lang) : current.toUpperCase(Locale.ENGLISH).startsWith(lang.toUpperCase(Locale.ENGLISH));
+        return current == null ? super.isLanguage(lang) : isLanguage(current, lang);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AbstractBeanModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AbstractBeanModelTest.java
@@ -78,7 +78,10 @@ public abstract class AbstractBeanModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "@xml:lang", "en-US");
         assertXPathValue(context, "count(@xml:*)", Double.valueOf(1));
         assertXPathValue(context, "lang('en')", Boolean.TRUE);
+        assertXPathValue(context, "lang('en-US')", Boolean.TRUE);
         assertXPathValue(context, "lang('fr')", Boolean.FALSE);
+        // lang() must match a whole subtag, not any leading prefix
+        assertXPathValue(context, "lang('e')", Boolean.FALSE);
     }
 
     /**

--- a/src/test/java/org/apache/commons/jxpath/ri/model/AbstractXMLModelTest.java
+++ b/src/test/java/org/apache/commons/jxpath/ri/model/AbstractXMLModelTest.java
@@ -360,6 +360,8 @@ public abstract class AbstractXMLModelTest extends AbstractJXPathTest {
         assertXPathValue(context, "//product/prix/@xml:lang", "fr");
         // lang() used the built-in xml:lang attribute
         assertXPathValue(context, "//product/prix[lang('fr')]", "934.99");
+        // a leading prefix that is not a whole subtag must not match xml:lang="fr"
+        assertXPathValue(context, "count(//product/prix[lang('f')])", Double.valueOf(0));
         // Default language
         assertXPathValue(context, "//product/price:sale[lang('en')]/saleEnds", "never");
     }


### PR DESCRIPTION
Thanks for your contribution to [Apache Commons](https://commons.apache.org/)!

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.

`NodePointer.isLanguage` and its `DOMNodePointer`/`JDOMNodePointer` overrides test the language with `String.startsWith`, so `lang()` matches any leading character prefix of the node's `xml:lang` (or the locale name) instead of a whole subtag. I noticed it reading the `lang()` predicate path: a node with `xml:lang="fr"` satisfies `lang('f')`, and a locale of `en-US` satisfies `lang('e')` and `lang('en-')`, all of which must be false per XPath 1.0 section 4.3, which matches only when the argument equals the tag or a subtag delimited by `-`. Since `lang()` is used in predicates to select nodes, the over-match changes which nodes a filter returns for caller-supplied `xml:lang` data. The fix requires an exact case-insensitive match or a `lang-` prefix, in one shared helper used by all three implementations. The added assertions fail on the current code (`lang('f')` and `lang('e')` return true) and pass with the change.
